### PR TITLE
Fix issues with source install

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default[:consul][:checksums] = {
   '0.2.0_linux_amd64' => '2802ce8e173ee37e1a1e992ba230963e09d4b41ce4ac60c1222714c036787b4f',
   '0.2.0_windows_386' => '353da0b0321293d81a1e2351b7bc6902d462c6573e44a4495d1a61df6b0a0179'
 }
+repository node[:consul][:source_revision] = "master"
 
 # Service attributes
 default[:consul][:service_mode] = 'bootstrap'

--- a/recipes/source_install.rb
+++ b/recipes/source_install.rb
@@ -17,17 +17,24 @@
 
 include_recipe 'golang::default'
 
-# TODO: Regular expression to support branches?
-source_version = "v#{node[:consul][:version]}"
+directory "#{node[:go][:gopath]}/src/github.com/hashicorp" do
+  owner 'root'
+  group 'root'
+  mode 00755
+  recursive true
+  action :create
+end
 
-env = {
- 'PATH' => "#{node[:go][:install_dir]}/go/bin:#{node[:go][:install_dir]}/bin:#{node[:go][:gobin]}:/usr/bin",
- 'GOPATH' => node[:go][:gopath]
-}
+git "#{node[:go][:gopath]}/src/github.com/hashicorp/consul" do
+  repository "https://github.com/hashicorp/consul.git"
+  reference node[:consul][:source_revision]
+  action :checkout
+end
 
-ark 'consul' do
-  has_binaries ['bin/consul']
-  environment env
-  url URI.join('https://github.com/hashicorp/consul/archive/', "#{source_version}.tar.gz").to_s
+golang_package 'github.com/hashicorp/consul' do
   action :install
+end
+
+link "#{node[:consul][:install_dir]}/consul" do
+  to "#{default[:go][:gobin]}/consul"
 end


### PR DESCRIPTION
To use golang_package resource is the easiest way to build Consul from the source code.

The reason why git repository is used is to lock the version. I've added an attribute to specify the  git revision. But when installing dependencies, 'go get' always uses the latest version. So you don't want to change the attribute other than 'master'. Indeed using 'v0.2.0' for the revision doesn't work due to the  dependency problem.
