### PR TITLE
Add consul::ui recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ Ubuntu 12.04, 14.04
   </tr>
 </table>
 
+### Consul UI Attributes
+
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['consul']['client_address']</tt></td>
+    <td>String</td>
+    <td>Address to bind to</td>
+    <td><tt>0.0.0.0</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['ui_dir']</tt></td>
+    <td>String</td>
+    <td>Location to download the UI to</td>
+    <td><tt>/var/lib/consul/ui</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['serve_ui']</tt></td>
+    <td>Boolean</td>
+    <td>Determines whether the consul service also serve's the UI</td>
+    <td><tt>false</tt></td>
+  </tr>
+</table>
+
 ## Usage
 
 ### consul::default
@@ -86,6 +115,20 @@ Include `consul::source_install` in your node's `run_list`:
 {
   "run_list": [
     "recipe[consul::source_install]"
+  ]
+}
+```
+
+### consul::ui
+
+This installs the UI into a specified directory.
+
+Include `consul::ui` in your node's `run_list`:
+
+```json
+{
+  "run_list": [
+    "recipe[consul::ui]"
   ]
 }
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,3 +37,8 @@ default[:consul][:source_revision] = "master"
 default[:consul][:service_mode] = 'bootstrap'
 default[:consul][:data_dir] = '/var/lib/consul'
 default[:consul][:servers] = []
+
+# UI attributes
+default[:consul][:client_addr] = '0.0.0.0'
+default[:consul][:ui_dir] = '/var/lib/consul/ui'
+default[:consul][:serve_ui] = false

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -13,6 +13,10 @@ else
   raise 'node[:consul][:service_mode] must be "bootstrap", "server", or "client"'
 end
 
+if node[:consul][:serve_ui]
+  service_params = "#{service_params} -ui-dir #{node[:consul][:ui_dir]}/consul_ui -client #{node[:consul][:client_addr]}"
+end
+
 template '/etc/init.d/consul' do
   source 'consul-init.erb'
   mode 0755

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -1,0 +1,28 @@
+# Copyright 2014 Benny Wong <benny@bwong.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ark'
+
+install_version = [node[:consul][:version], "web_ui"].join('_')
+install_checksum = node[:consul][:checksums].fetch(install_version)
+
+ark 'consul_ui' do
+  path node[:consul][:ui_dir]
+  version node[:consul][:version]
+  checksum install_checksum
+  url URI.join(node[:consul][:base_url], "#{install_version}.zip").to_s
+  action :put
+end
+


### PR DESCRIPTION
Adds a recipe to install and possibly serve the [Consul UI](https://github.com/hashicorp/consul/tree/master/ui) and optionally serve it.

This PR also includes checksums for Consul [v0.2.1](https://github.com/hashicorp/consul/blob/v0.2.1/CHANGELOG.md#021-may-20-2014)
