### PR TITLE
support reload via init

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -31,6 +31,6 @@ template '/etc/init.d/consul' do
 end
 
 service 'consul' do
-  supports status: true, restart: true
+  supports status: true, restart: true, reload: true
   action [:enable, :start]
 end

--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -86,8 +86,23 @@ case "$1" in
         exit 1
     fi
     ;;
+    reload)
+    if is_running; then
+        echo -n "Reloading $NAME..."
+        kill -HUP `get_pid`
+        sleep 1
+        echo
+
+        if ! is_running; then
+            echo "$NAME has died, see $LOGFILE"
+            exit 1
+        fi
+    else
+        echo "$NAME not running"
+    fi
+    ;;
     *)
-    echo "Usage: $0 {start|stop|restart|status}"
+    echo "Usage: $0 {start|stop|restart|reload|status}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
This pr adds a reload action to the init file and service, so we can use notifications on changes to gracefully reload (pr in the pipeline, depends on what you decide to do with my others).
