### PR TITLE
Delay the consul reload when config file changes

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -113,7 +113,7 @@ when 'init'
   service 'consul' do
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :reload, "file[#{node[:consul][:config_dir]}/default.json]", :immediately
+    subscribes :reload, "file[#{node[:consul][:config_dir]}/default.json]", :delayed
   end
 when 'runit'
   include_recipe 'runit'


### PR DESCRIPTION
On first install, the consul service may not exist when we create the `node[:consul][:config_dir]}/default.json`. This leads to an error as the service tries to restart itself (thanks to `subscribes`) before the `/etc/init.d/consul` is created.
