### PR TITLE
Restart consul service on configuration change

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -113,7 +113,7 @@ when 'init'
   service 'consul' do
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :reload, "file[#{node[:consul][:config_dir]}/default.json]", :delayed
+    subscribes :restart, "file[#{node[:consul][:config_dir]}/default.json]", :delayed
   end
 when 'runit'
   include_recipe 'runit'
@@ -121,7 +121,7 @@ when 'runit'
   runit_service 'consul' do
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :reload, "file[#{node[:consul][:config_dir]}/default.json]", :immediately
+    subscribes :restart, "file[#{node[:consul][:config_dir]}/default.json]", :immediately
     log true
     options(
       consul_binary: "#{node[:consul][:install_dir]}/consul",


### PR DESCRIPTION
Reloading Consul has no effect when changing agent configuration

Only checks and services definitions are reloadable:

> The service and check definitions support being updated during a reload.
> 
> -- http://www.consul.io/docs/agent/options.html#toc_2
