### PR TITLE
Fix resource order to suppress error when service start before create default.json.

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -111,6 +111,14 @@ end
 
 consul_config_filename = File.join(node['consul']['config_dir'], 'default.json')
 
+file consul_config_filename do
+  user consul_user
+  group consul_group
+  mode 0600
+  action :create
+  content JSON.pretty_generate(service_config, quirks_mode: true)
+end
+
 case node['consul']['init_style']
 when 'init'
   template '/etc/init.d/consul' do
@@ -139,12 +147,4 @@ when 'runit'
       config_dir: node['consul']['config_dir'],
     )
   end
-end
-
-file consul_config_filename do
-  user consul_user
-  group consul_group
-  mode 0600
-  action :create
-  content JSON.pretty_generate(service_config, quirks_mode: true)
 end


### PR DESCRIPTION
Revert change at #36 to suppress error when service start.
Consul service need -data-dir option or `data_dir` value in /etc/consul.d/default.json.

following log is /var/log/consul.log when error has occuurred.

```
==> Must specify data directory using -data-dir
```

Referenced issue(#33) from #36 is already fixed at d1f21164d03f2cf74b995e61219565821189b5f3.
Current recipe that has subscribe with delayed option doesn't need #36 .
