### PR TITLE
Delay runit restart on config file change

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -149,7 +149,7 @@ when 'runit'
   runit_service 'consul' do
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :restart, "file[#{consul_config_filename}]", :immediately
+    subscribes :restart, "file[#{consul_config_filename}]", :delayed
     log true
     options(
       consul_binary: "#{node['consul']['install_dir']}/consul",


### PR DESCRIPTION
On first install, the consul service may not exist when we create the
`node[:consul][:config_dir]}/default.json`. This leads to an error as
the service tries to restart itself (thanks to `subscribes`) before the
`/etc/init.d/consul` is created.

This parallels the init.d change d1f21164d03f2cf74b995e61219565821189b5f3 by jubianchi
authored on Jul 25 but for runit
