### PR TITLE
fixed foodcritic FC001 warnings

### DIFF
--- a/templates/default/sv-consul-log-run.erb
+++ b/templates/default/sv-consul-log-run.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
-exec chpst -u '<%= node["consul"]["service_user"] %>':'<%= node["consul"]["service_group"] %>'  \
+exec chpst -u '<%= node['consul']['service_user'] %>':'<%= node['consul']['service_group'] %>'  \
   svlogd                                                                                    \
   /var/log/consul                                                                           \
 #                                                                                           #

--- a/templates/default/sv-consul-run.erb
+++ b/templates/default/sv-consul-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
-exec chpst -u '<%= node["consul"]["service_user"] %>':'<%= node["consul"]["service_group"] %>'  \
-  <%= @options["consul_binary"] %>                                                           \
+exec chpst -u '<%= node['consul']['service_user'] %>':'<%= node['consul']['service_group'] %>'  \
+  <%= @options['consul_binary'] %>                                                           \
   agent                                                                                     \
-  -config-dir '<%= @options["config_dir"] %>'                                                \
+  -config-dir '<%= @options['config_dir'] %>'                                                \
 #                                                                                           #


### PR DESCRIPTION
fixing chef styling warnings with foodcritic and this will remove failing mark on chef supermarket page
https://supermarket.getchef.com/cookbooks/consul#foodcritic
