### PR TITLE
Use port and name in the service def file path

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache v2.0'
 description 'Installs/Configures consul'
 long_description 'Installs/Configures consul'
-version '0.6.0'
+version '0.5.0'
 
 recipe 'consul', 'Installs and starts consul service.'
 recipe 'consul::install_binary', 'Installs consul service from binary.'


### PR DESCRIPTION
It allows us to register a service multiple times with different ports
(for a service that exposes multiple ports)

NOTE: This is a breaking change since port is required to delete a service
