### PR TITLE
Use id (if present) in the service def file path

### DIFF
--- a/resources/service_def.rb
+++ b/resources/service_def.rb
@@ -47,7 +47,8 @@ def self.validate_check(check)
 end
 
 def path
-  ::File.join(node['consul']['config_dir'], "service-#{name}.json")
+  # Use id (if present) instead of name since it is unique
+  ::File.join(node['consul']['config_dir'], "service-#{id || name}.json")
 end
 
 def to_json


### PR DESCRIPTION
It allows us to register a service multiple times with different
ports (for a service that exposes multiple ports). Pass unique service
id when registering a service.
