### PR TITLE
fixes #72. 

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -127,6 +127,8 @@ file consul_config_filename do
   mode 0600
   action :create
   content JSON.pretty_generate(service_config, quirks_mode: true)
+  # https://github.com/johnbellone/consul-cookbook/issues/72
+  notifies :restart, "service[consul]"
 end
 
 case node['consul']['init_style']


### PR DESCRIPTION
When the configuration JSON is updated the service won't currently notice. This will ensure changes are picked up
