### PR TITLE
extra params using node object as base

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ Installs and configures [Consul][1].
     </td>
     <td><tt>nil</tt></td>
   </tr>
+  <tr>
+    <td><tt>['consul']['extra_params']</tt></td>
+    <td>hash</td>
+    <td>
+       Pass a hash of extra params to the default.json config file
+    </td>
+    <td><tt>{}</tt></td>
+  </tr>
+
 </table>
 
 ### Consul UI Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -70,3 +70,4 @@ default['consul']['client_interface'] = nil
 default['consul']['client_addr'] = '0.0.0.0'
 default['consul']['ui_dir'] = '/var/lib/consul/ui'
 default['consul']['serve_ui'] = false
+default['consul']['extra_params'] = {}

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -63,7 +63,7 @@ consul_directories.each do |dirname|
 end
 
 # Determine service params
-service_config = {}
+service_config = JSON.parse(node['consul']['extra_params'].to_json)
 service_config['data_dir'] = node['consul']['data_dir']
 num_cluster = node['consul']['bootstrap_expect'].to_i
 


### PR DESCRIPTION
Extra params, same as before just fixed up.

The reason I added this was to support the multitude of uncommonly used flags that consul supports (in my disable_remote_exec)
