### PR TITLE
Add some additional options to the service_config hash.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache v2.0'
 description 'Installs/Configures consul'
 long_description 'Installs/Configures consul'
-version '0.5.2'
+version '0.5.1'
 
 recipe 'consul', 'Installs and starts consul service.'
 recipe 'consul::install_binary', 'Installs consul service from binary.'


### PR DESCRIPTION
This allows those options to be configured through node attributes. Before, they didn't seem to work at all.

Would you consider merging this?
