### PR TITLE
{1..10} does not work in sh

### DIFF
--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -52,7 +52,7 @@ case "$1" in
     if is_running; then
         echo -n "Stopping $NAME..."
         kill -INT `get_pid`
-        for i in {1..10}
+        for i in 1 2 3 4 5 6 7 8 9 10
         do
             if ! is_running; then
                 break


### PR DESCRIPTION
Unfortunately, {1..10} in for loops in /bin/sh does not work. To keep /bin/sh I'm using 10 numbers in the loop (or we could switch to bash, but sh is safer).
