### PR TITLE
Allow custom data bag and data bag item for consul encrypt

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,7 +61,7 @@ end
 default['consul']['servers'] = []
 default['consul']['init_style'] = 'init'   # 'init', 'runit'
 
-case node['consul']['init_style'] 
+case node['consul']['init_style']
 when 'runit'
   default['consul']['service_user'] = 'consul'
   default['consul']['service_group'] = 'consul'
@@ -78,6 +78,10 @@ default['consul']['ports'] = {
   'serf_wan' => 8302,
   "server"   => 8300,
 }
+
+# Consul DataBag
+default['consul']['data_bag'] = 'consul'
+default['consul']['data_bag_encrypt_item'] = 'encrypt'
 
 # Gossip encryption
 default['consul']['encrypt_enabled'] = false

--- a/libraries/encrypt.rb
+++ b/libraries/encrypt.rb
@@ -4,7 +4,7 @@ class Chef
     def consul_encrypted_dbi
       begin
         # loads the secret from /etc/chef/encrypted_data_bag_secret
-        Chef::EncryptedDataBagItem.load('consul', 'encrypt')
+        Chef::EncryptedDataBagItem.load(node['consul']['data_bag'], node['consul']['data_bag_encrypt_item'])
       rescue Net::HTTPServerException => e
         raise e unless e.response.code == '404'
       end


### PR DESCRIPTION
Don't enforce users to use 'consul' 'encrypt' data bag item
