### PR TITLE
Prefer id over name consul check filename

### DIFF
--- a/providers/check_def.rb
+++ b/providers/check_def.rb
@@ -18,6 +18,11 @@
 use_inline_resources
 
 action :create do
+  file new_resource.path_with_name do
+    action :delete
+    only_if { new_resource.id }
+  end
+
   file new_resource.path do
     user node['consul']['service_user']
     group node['consul']['service_group']

--- a/resources/check_def.rb
+++ b/resources/check_def.rb
@@ -31,6 +31,10 @@ def path
   ::File.join(node['consul']['config_dir'], "check-#{id || name}.json")
 end
 
+def path_with_name
+  ::File.join(node['consul']['config_dir'], "check-#{name}.json")
+end
+
 def to_json
   JSON.pretty_generate(to_hash)
 end

--- a/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_create.rb
+++ b/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_create.rb
@@ -1,0 +1,8 @@
+include_recipe "consul"
+consul_check_def "dummy name" do
+  id "uniqueid"
+  script "curl http://localhost:8888/health"
+  interval "10s"
+  ttl "50s"
+  notes "Blahblah"
+end

--- a/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_delete.rb
+++ b/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_delete.rb
@@ -1,0 +1,5 @@
+include_recipe "consul"
+consul_check_def "dummy name" do
+  id "uniqueid"
+  action :delete
+end

--- a/spec/fixtures/cookbooks/consul_spec/recipes/check_def_without_id_create.rb
+++ b/spec/fixtures/cookbooks/consul_spec/recipes/check_def_without_id_create.rb
@@ -1,0 +1,7 @@
+include_recipe "consul"
+consul_check_def "dummy name" do
+  script "curl http://localhost:8888/health"
+  interval "10s"
+  ttl "50s"
+  notes "Blahblah"
+end

--- a/spec/fixtures/cookbooks/consul_spec/recipes/check_def_without_id_delete.rb
+++ b/spec/fixtures/cookbooks/consul_spec/recipes/check_def_without_id_delete.rb
@@ -1,0 +1,4 @@
+include_recipe "consul"
+consul_check_def "dummy name" do
+  action :delete
+end

--- a/spec/unit/resources/check_def_spec.rb
+++ b/spec/unit/resources/check_def_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'chefspec/berkshelf'
+
+describe_resource "consul_check_def" do
+  describe "with id" do
+    let(:check_def_path) { "/etc/consul.d/check-uniqueid.json" }
+
+    describe "create" do
+      let(:example_recipe) { "consul_spec::check_def_with_id_create" }
+
+      it "removes any check previously registered by name" do
+        expect(chef_run).to delete_file("/etc/consul.d/check-dummy name.json")
+      end
+
+      it "register the check" do
+        ['"name": "dummy name"', '"id": "uniqueid"', '"script": "curl http://localhost:8888/health"',
+            '"interval": "10s"', '"ttl": "50s"', '"notes": "Blahblah"'].each do |content|
+          expect(chef_run).to render_file(check_def_path)
+            .with_content(content)
+        end
+      end
+    end
+
+    describe "delete" do
+      let(:example_recipe) { "consul_spec::check_def_with_id_delete" }
+
+      it "de-register the check" do
+        expect(chef_run).to delete_file(check_def_path)
+      end
+    end
+  end
+
+  describe "without id" do
+    let(:check_def_path) { "/etc/consul.d/check-dummy name.json" }
+
+    describe "create" do
+      let(:example_recipe) { "consul_spec::check_def_without_id_create" }
+
+      it "does not remove checks previously registered by name" do
+        expect(chef_run).not_to delete_file("/etc/consul.d/check-dummy name.json")
+      end
+
+      it "register the check" do
+        ['"name": "dummy name"', '"script": "curl http://localhost:8888/health"',
+            '"interval": "10s"', '"ttl": "50s"', '"notes": "Blahblah"'].each do |content|
+          expect(chef_run).to render_file(check_def_path)
+            .with_content(content)
+        end
+      end
+    end
+
+    describe "delete" do
+      let(:example_recipe) { "consul_spec::check_def_without_id_delete" }
+
+      it "de-register the check" do
+        expect(chef_run).to delete_file(check_def_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #99. I chose to do it with a fallback, the same was as for service definitions, as id isn't required, and name is used as id in consul if id isn't specified.
