### PR TITLE
Let user decide join strategy on cluster mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Installs and configures [Consul][1] client, server and UI.
     <td><tt>[]</tt></td>
   </tr>
   <tr>
+    <td><tt>['consul']['retry_on_join']</tt></td>
+    <td>Boolean</td>
+    <td>Set to true to wait for servers to be up before try to elect a leader</td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
     <td><tt>['consul']['bind_addr']</tt></td>
     <td>String</td>
     <td>address that should be bound to for internal cluster communications</td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,8 @@ default['consul']['source_revision'] = 'master'
 
 # Service attributes
 default['consul']['service_mode'] = 'bootstrap'
+default['consul']['retry_on_join'] = false
+
 # In the cluster mode, set the default cluster size to 3
 default['consul']['bootstrap_expect'] = 3
 default['consul']['data_dir'] = '/var/lib/consul'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -62,6 +62,7 @@ end
 service_config = JSON.parse(node['consul']['extra_params'].to_json)
 service_config['data_dir'] = node['consul']['data_dir']
 num_cluster = node['consul']['bootstrap_expect'].to_i
+join_mode = node['consul']['retry_on_join'] ? 'retry_join' : 'start_join'
 
 case node['consul']['service_mode']
 when 'bootstrap'
@@ -71,15 +72,15 @@ when 'cluster'
   service_config['server'] = true
   if num_cluster > 1
     service_config['bootstrap_expect'] = num_cluster
-    service_config['start_join'] = node['consul']['servers']
+    service_config[join_mode] = node['consul']['servers']
   else
     service_config['bootstrap'] = true
   end
 when 'server'
   service_config['server'] = true
-  service_config['start_join'] = node['consul']['servers']
+  service_config[join_mode] = node['consul']['servers']
 when 'client'
-  service_config['start_join'] = node['consul']['servers']
+  service_config[join_mode] = node['consul']['servers']
 else
   Chef::Application.fatal! %Q(node['consul']['service_mode'] must be "bootstrap", "cluster", "server", or "client")
 end

--- a/spec/unit/recipes/_service_spec.rb
+++ b/spec/unit/recipes/_service_spec.rb
@@ -103,6 +103,23 @@ describe_recipe 'consul::_service' do
     end
   end
 
+  context 'with a cluster service_mode, bootstrap_expect > 1 and a server list to join in retry mode' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(node_attributes) do |node|
+        node.set['consul']['service_mode'] = 'cluster'
+        node.set['consul']['bootstrap_expect'] = '3'
+        node.set['consul']['servers'] = [ 'server1', 'server2', 'server3' ]
+      end.converge(described_recipe)
+    end
+    it do
+      expect(chef_run).to create_file('/etc/consul.d/default.json')
+        .with_content(/retry_join/)
+        .with_content(/server9/)
+        .with_content(/server2/)
+        .with_content(/server3/)
+    end
+  end
+
   context 'with a cluster service_mode, bootstrap_expect > 1, and a server list to join' do
     let(:chef_run) do
       ChefSpec::Runner.new(node_attributes) do |node|


### PR DESCRIPTION
consul allow to wait for all servers to be up and running before elect a consul leader. For that case, `retry_join` must be used instead of `start_join`. 
