### PR TITLE
Add Service Watch LWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,12 @@ the `consul::ui` recipe in your node's `run_list`.
       handler "chef-client"
     end
 
+##### Adding service watch
+    consul_service_watch_def 'service-name' do
+		  passingonly true
+      handler "chef-client"
+    end
+		
 ##### Adding service without check
 
     consul_service_def 'voice1' do

--- a/providers/service_watch_def.rb
+++ b/providers/service_watch_def.rb
@@ -1,0 +1,35 @@
+#
+# Copyright 2014 John Bellone <jbellone@bloomberg.net>
+# Copyright 2014 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use_inline_resources
+
+action :create do
+  file new_resource.path do
+    user node['consul']['service_user']
+    group node['consul']['service_group']
+    mode 0600
+    content new_resource.to_json
+
+    action :create
+  end
+end
+
+action :delete do
+  file new_resource.path do
+    action :delete
+  end
+end

--- a/resources/service_watch_def.rb
+++ b/resources/service_watch_def.rb
@@ -1,0 +1,45 @@
+#
+# Copyright 2014 John Bellone <jbellone@bloomberg.net>
+# Copyright 2014 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'json'
+
+actions :create, :delete
+default_action :create
+
+attribute :service, name_attribute: true, required: true, kind_of: String
+attribute :handler, required: true, kind_of: String
+attribute :passingonly, required: false, kind_of: [TrueClass, FalseClass]
+attribute :tag, required: false, kind_of: String
+
+def path
+  ::File.join(node['consul']['config_dir'], "service-watch-#{name}.json")
+end
+
+def to_json
+  JSON.pretty_generate({'watches'=> [to_hash]})
+end
+
+def to_hash
+  hash =  {
+    type: "service"
+  }
+  hash[:service] = name
+  hash[:handler] = handler unless handler.nil?
+  hash[:tag] = tag unless tag.nil?
+  hash[:passingonly] = passingonly unless passingonly.nil?
+  hash
+end


### PR DESCRIPTION
Small addition to support the definition of a service watch.  The same conventions used for event and key watch have been applied.