### PR TITLE
fix for start then restart

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache v2.0'
 description 'Installs/Configures Consul client, server and UI.'
 long_description 'Installs/Configures Consul client, server and UI.'
-version '0.6.0'
+version '0.6.1'
 
 recipe 'consul', 'Installs and starts consul service.'
 recipe 'consul::install_binary', 'Installs consul service from binary.'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -210,15 +210,23 @@ when 'init'
       consul_binary: "#{node['consul']['install_dir']}/consul",
       config_dir: node['consul']['config_dir'],
     )
-    notifies :restart, 'service[consul]', :immediately
+    notifies :restart, 'service[consul]', :delayed
   end
 
   service 'consul' do
     provider Chef::Provider::Service::Upstart if platform?("ubuntu")
     supports status: true, restart: true, reload: true
-    action [:enable, :start]
+    action :nothing
     subscribes :restart, "file[#{consul_config_filename}", :delayed
   end
+
+  ruby_block "consul_start" do
+    block {}
+    action :run
+    notifies :start, "service[consul]", :delayed
+    notifies :enable, "service[consul]", :delayed
+  end
+
 when 'runit'
   runit_service 'consul' do
     supports status: true, restart: true, reload: true


### PR DESCRIPTION
Had a problem converging cluster nodes once a bootstrap node existed. Essentially it was doing this:

    service consul start & sleep 3 && service consul restart
    [1] 6031
    Starting consul
    [1]+  Done                    service consul start
    Stopping consul.............
    consul not stopped; may still be shutting down or shutdown may have failed
    Unable to stop consul, will not attempt to start

action [:start, :enable] was starting the consul process, which was followed immediately by a :restart which would fail.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/johnbellone/consul-cookbook/104)
<!-- Reviewable:end -->
