### PR TITLE
Make upstart script respawn consul on crash

### DIFF
--- a/templates/default/consul.conf.erb
+++ b/templates/default/consul.conf.erb
@@ -18,3 +18,6 @@ end script
 post-start exec initctl emit consul-up
 
 kill signal INT
+
+respawn
+respawn limit 10 10


### PR DESCRIPTION
This could be configurable (whether to respawn, and the count/interval/unlimited), but I think it could be a future PR.

Is there a reason to not respawn if consul crashes?