### PR TITLE
Upgradeable Consul Binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,6 @@ Following attributes, if exist in the [encrypted databag][7], override the node 
     <td><tt>nil</tt></td>
   </tr>
   <tr>
-    <td><tt>['consul']['ui_dir']</tt></td>
-    <td>String</td>
-    <td>Location to download the UI to</td>
-    <td><tt>/var/lib/consul/ui</tt></td>
-  </tr>
-  <tr>
     <td><tt>['consul']['serve_ui']</tt></td>
     <td>Boolean</td>
     <td>Determines whether the consul service also serve's the UI</td>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,11 +15,11 @@
 # limitations under the License.
 #
 
-default['consul']['base_url'] = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
-default['consul']['version'] = '0.4.1'
+default['consul']['base_url']       = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
+default['consul']['version']        = '0.4.1'
 default['consul']['install_method'] = 'binary'
-default['consul']['install_dir'] = '/usr/local/bin'
-default['consul']['checksums'] = {
+default['consul']['install_dir']    = '/usr/local/bin'
+default['consul']['checksums']      = {
   '0.3.0_darwin_amd64' => '9dfbc70c01ebbc3e7dba0e4b31baeddbdcbd36ef99f5ac87ca6bbcc7405df405',
   '0.3.0_linux_386'    => '2513496374f8f15bda0da4da33122e93f82ce39f661ee3e668c67a5b7e98fd5f',
   '0.3.0_linux_amd64'  => 'da1337ab3b236bad19b791a54a8df03a8c2a340500a392000c21608696957b15',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -106,7 +106,6 @@ default['consul']['advertise_interface'] = nil
 default['consul']['client_interface'] = nil
 
 # UI attributes
-default['consul']['client_addr'] = '0.0.0.0'
-default['consul']['ui_dir'] = '/var/lib/consul/ui'
-default['consul']['serve_ui'] = false
+default['consul']['client_addr']  = '0.0.0.0'
+default['consul']['serve_ui']     = false
 default['consul']['extra_params'] = {}

--- a/libraries/consul.rb
+++ b/libraries/consul.rb
@@ -1,0 +1,56 @@
+#
+# Copyright 2014-2015 John Bellone <jbellone@bloomberg.net>
+# Copyright 2014-2015 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  module Consul
+    class << self
+      def active_binary(node)
+        File.join(node['consul']['install_dir'], 'consul')
+      end
+
+      def cached_archive(node)
+        File.join(Chef::Config[:file_cache_path], File.basename(remote_url(node)))
+      end
+
+      def latest_binary(node)
+        File.join(install_path(node), 'consul')
+      end
+
+      def remote_checksum(node)
+        node['consul']['checksums'].fetch(remote_filename(node))
+      end
+
+      def remote_filename(node)
+        [node['consul']['version'], node['os'], arch(node)].join('_')
+      end
+
+      def remote_url(node)
+        node['consul']['base_url'] % { version: remote_filename(node) }
+      end
+
+      def install_path(node)
+        File.join(['/opt', 'consul', node['consul']['version']])
+      end
+
+      private
+
+        def arch(node)
+          node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
+        end
+    end
+  end
+end

--- a/libraries/consul.rb
+++ b/libraries/consul.rb
@@ -42,6 +42,10 @@ class Chef
         node['consul']['base_url'] % { version: remote_filename(node) }
       end
 
+      def source_binary(node)
+        File.join(node['go']['gobin'], 'consul')
+      end
+
       def install_path(node)
         File.join(['/opt', 'consul', node['consul']['version']])
       end

--- a/libraries/consul_ui.rb
+++ b/libraries/consul_ui.rb
@@ -1,0 +1,46 @@
+#
+# Copyright 2014-2015 John Bellone <jbellone@bloomberg.net>
+# Copyright 2014-2015 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Chef
+  module ConsulUI
+    class << self
+      def active_path(node)
+        File.join(node['consul']['data_dir'], 'ui')
+      end
+
+      def cached_archive(node)
+        File.join(Chef::Config[:file_cache_path], File.basename(remote_url(node)))
+      end
+
+      def install_path(node)
+        File.join(['/opt', 'consul_ui', node['consul']['version']])
+      end
+
+      def remote_filename(node)
+        [node['consul']['version'], 'web_ui'].join('_')
+      end
+
+      def remote_checksum(node)
+        node['consul']['checksums'].fetch(remote_filename(node))
+      end
+
+      def remote_url(node)
+        node['consul']['base_url'] % { version: remote_filename(node) }
+      end
+    end
+  end
+end

--- a/libraries/consul_ui.rb
+++ b/libraries/consul_ui.rb
@@ -30,6 +30,10 @@ class Chef
         File.join(['/opt', 'consul_ui', node['consul']['version']])
       end
 
+      def latest_dist(node)
+        File.join(install_path(node), 'dist')
+      end
+
       def remote_filename(node)
         [node['consul']['version'], 'web_ui'].join('_')
       end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -6,7 +6,7 @@ if defined?(ChefSpec)
   def delete_consul_service_def(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:consul_service_def, :delete, resource_name)
   end
-  
+
   def create_consul_event_watch_def(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:consul_event_watch_def, :create, resource_name)
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ supports 'ubuntu', '= 10.04'
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
-depends 'ark'
+depends 'libarchive'
 depends 'chef-provisioning'
 depends 'golang', '~> 1.4'
 depends 'runit'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -206,10 +206,6 @@ when 'init'
   template init_file do
     source init_tmpl
     mode 0755
-    variables(
-      consul_binary: "#{node['consul']['install_dir']}/consul",
-      config_dir: node['consul']['config_dir'],
-    )
     notifies :restart, 'service[consul]', :immediately
   end
 
@@ -225,10 +221,6 @@ when 'runit'
     action [:enable, :start]
     subscribes :restart, "file[#{consul_config_filename}]", :delayed
     log true
-    options(
-      consul_binary: "#{node['consul']['install_dir']}/consul",
-      config_dir: node['consul']['config_dir'],
-    )
   end
 
   service 'consul' do

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -103,7 +103,7 @@ iface_addr_map.each_pair do |interface,addr|
 end
 
 if node['consul']['serve_ui']
-  service_config['ui_dir'] = node['consul']['ui_dir']
+  service_config['ui_dir']      = Chef::ConsulUI.active_path(node)
   service_config['client_addr'] = node['consul']['client_addr']
 end
 

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -213,13 +213,15 @@ when 'init'
     provider Chef::Provider::Service::Upstart if platform?("ubuntu")
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :restart, "file[#{consul_config_filename}", :delayed
+    subscribes :restart, "file[#{consul_config_filename}"
+    subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
   end
 when 'runit'
   runit_service 'consul' do
     supports status: true, restart: true, reload: true
     action [:enable, :start]
-    subscribes :restart, "file[#{consul_config_filename}]", :delayed
+    subscribes :restart, "file[#{consul_config_filename}]"
+    subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
     log true
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,4 +15,11 @@
 # limitations under the License.
 #
 
-include_recipe "consul::install_#{node['consul']['install_method']}"
+case node['consul']['install_method']
+when 'binary'
+  include_recipe 'consul::install_binary'
+when 'source'
+  include_recipe 'consul::install_source'
+else
+  Chef::Application.fatal!("[consul::default] unknown install method, method=#{node['consul']['install_method']}")
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,4 +16,3 @@
 #
 
 include_recipe "consul::install_#{node['consul']['install_method']}"
-include_recipe 'consul::_service'

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -15,21 +15,27 @@
 # limitations under the License.
 #
 
-include_recipe 'ark::default'
+include_recipe 'libarchive::default'
 
-install_arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
-install_version = [node['consul']['version'], node['os'], install_arch].join('_')
-install_checksum = node['consul']['checksums'].fetch(install_version)
-
-ark 'consul' do
-  path node['consul']['install_dir']
-  version node['consul']['version']
-  checksum install_checksum
-  url node['consul']['base_url'] % { version: install_version }
-  action :dump
+archive = remote_file Chef::Consul.cached_archive(node) do
+  source Chef::Consul.remote_url(node)
+  checksum Chef::Consul.remote_checksum(node)
 end
 
-file File.join(node['consul']['install_dir'], 'consul') do
-  mode '0755'
-  action :touch
+libarchive_file 'consul.zip' do
+  path archive.path
+  extract_to Chef::Consul.install_path(node)
+  extract_options :no_overwrite
+
+  action :extract
+end
+
+# JW TODO: Remove after next major release.
+file Chef::Consul.active_binary(node) do
+  action :delete
+  not_if "test -L #{Chef::Consul.active_binary(node)}"
+end
+
+link Chef::Consul.active_binary(node) do
+  to Chef::Consul.latest_binary(node)
 end

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -30,6 +30,11 @@ libarchive_file 'consul.zip' do
   action :extract
 end
 
+directory File.basename(Chef::Consul.active_binary(node)) do
+  recursive true
+  action :create
+end
+
 # JW TODO: Remove after next major release.
 file Chef::Consul.active_binary(node) do
   action :delete

--- a/recipes/install_binary.rb
+++ b/recipes/install_binary.rb
@@ -39,3 +39,5 @@ end
 link Chef::Consul.active_binary(node) do
   to Chef::Consul.latest_binary(node)
 end
+
+include_recipe 'consul::_service'

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -35,6 +35,8 @@ golang_package 'github.com/hashicorp/consul' do
   action :install
 end
 
-link File.join(node['consul']['install_dir'], 'consul') do
-  to File.join(node['go']['gobin'], 'consul')
+link Chef::Consul.active_binary(node) do
+  to Chef::Consul.source_binary(node)
 end
+
+include_recipe 'consul::_service'

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -35,6 +35,11 @@ golang_package 'github.com/hashicorp/consul' do
   action :install
 end
 
+directory File.basename(Chef::Consul.active_binary(node)) do
+  recursive true
+  action :create
+end
+
 link Chef::Consul.active_binary(node) do
   to Chef::Consul.source_binary(node)
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -13,15 +13,21 @@
 # limitations under the License.
 #
 
-include_recipe 'ark::default'
+include_recipe 'libarchive::default'
 
-install_version = [node['consul']['version'], 'web_ui'].join('_')
-install_checksum = node['consul']['checksums'].fetch(install_version)
+archive = remote_file Chef::ConsulUI.cached_archive(node) do
+  source Chef::ConsulUI.remote_url(node)
+  checksum Chef::ConsulUI.remote_checksum(node)
+end
 
-ark 'consul_ui' do
-  path node['consul']['data_dir']
-  home_dir node['consul']['ui_dir']
-  version node['consul']['version']
-  checksum install_checksum
-  url node['consul']['base_url'] % { version: install_version }
+libarchive_file 'consul_ui.zip' do
+  path archive.path
+  extract_to Chef::ConsulUI.install_path(node)
+  extract_options :no_overwrite
+
+  action :extract
+end
+
+link Chef::Consul.active(node) do
+  to Chef::Consul.install_path(node)
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -28,6 +28,6 @@ libarchive_file 'consul_ui.zip' do
   action :extract
 end
 
-link Chef::Consul.active(node) do
-  to Chef::Consul.install_path(node)
+link Chef::ConsulUI.active_path(node) do
+  to Chef::ConsulUI.latest_dist(node)
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -28,6 +28,12 @@ libarchive_file 'consul_ui.zip' do
   action :extract
 end
 
+# JW TODO: Remove after next major release.
+file Chef::ConsulUI.active_path(node) do
+  action :delete
+  not_if "test -L #{Chef::ConsulUI.active_path(node)}"
+end
+
 link Chef::ConsulUI.active_path(node) do
   to Chef::ConsulUI.latest_dist(node)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,10 @@ end
 at_exit { ChefSpec::Coverage.report! }
 
 RSpec.shared_context 'recipe tests', type: :recipe do
+  before do
+    stub_command("test -L /usr/local/bin/consul").and_return(true)
+  end
+
   let(:chef_run) { ChefSpec::Runner.new(node_attributes).converge(described_recipe) }
 
   def node_attributes
@@ -47,6 +51,10 @@ RSpec.shared_context 'recipe tests', type: :recipe do
 end
 
 RSpec.shared_context "resource tests", type: :resource do
+  before do
+    stub_command("test -L /usr/local/bin/consul").and_return(true)
+  end
+
   let(:chef_run) do
     ChefSpec::SoloRunner.new(node_attributes.merge(step_into)).converge(example_recipe)
   end

--- a/templates/default/consul.conf.erb
+++ b/templates/default/consul.conf.erb
@@ -10,7 +10,7 @@ script
     . <%= node['consul']['etc_config_dir'] %>
   fi
   export GOMAXPROCS=${GOMAXPROCS}
-  CMD="<%= @consul_binary %> agent -config-dir <%= @config_dir %>"
+  CMD="<%= Chef::Consul.active_binary(node) %> agent -config-dir <%= node['consul']['config_dir'] %>"
   LOGFILE="/var/log/consul.log"
   exec $CMD >> "$LOGFILE"
 end script

--- a/templates/default/sv-consul-run.erb
+++ b/templates/default/sv-consul-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
-exec chpst -u '<%= node[:consul][:service_user] %>':'<%= node[:consul][:service_group] %>'  \
-  <%= @options[:consul_binary] %>                                                           \
-  agent                                                                                     \
-  -config-dir '<%= @options[:config_dir] %>'                                                \
-#                                                                                           #
+
+exec 2>&1
+exec <%= node['runit']['chpst_bin'] %> \
+  -u <%= node['consul']['service_user'] %>:<%= node['consul']['service_group'] %> \
+  <%= Chef::Consul.active_binary(node) %> agent -config-dir <%= node['consul']['config_dir'] %>


### PR DESCRIPTION
This PR adds the ability to upgrade or downgrade the installed Consul binary to a different version than already present on the node.

Partial convergeance errors generated by the cookbook will also be remedied as a side effect from changing our archive management dependency from 'ark' to the more reliable and and 100% idempotent cousin - libarchive.