### PR TITLE
Delay return of control during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,14 @@ Installs and configures [Consul][1] client, server and UI.
     </td>
     <td><tt>nil</tt></td>
   </tr>
+  <tr>
+    <td><tt>['consul']['startup_sleep']</tt></td>
+    <td>Integer</td>
+    <td>
+        Delay to return-of-control when invoked via an init.d script. Protects consul from an early HUP.
+    </td>
+    <td><tt>3</tt></td>
+  </tr>
 </table>
 
 ### Databag Attributes (optional)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -138,3 +138,6 @@ default['consul']['extra_params'] = {}
 default['consul']['atlas_autojoin'] = false
 default['consul']['atlas_cluster'] = nil
 default['consul']['atlas_token'] = nil
+
+# Init script startup delay
+default['consul']['startup_sleep'] = 3

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -224,7 +224,8 @@ when 'init'
     source init_tmpl
     mode init_mode
     variables(
-      consul_logfile: node['consul']['logfile']
+      consul_logfile: node['consul']['logfile'],
+      startup_sleep: node['consul']['startup_sleep']
     )
     notifies :restart, 'service[consul]', :immediately
   end

--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -48,6 +48,7 @@ case "$1" in
         CONSULPID=$!
         echo $CONSULPID > "$PIDFILE"
         TIMEOUT="$STARTIMEOUT"
+        sleep <%= @startup_sleep %>
         while [ $TIMEOUT -gt 0 ]; do
             if is_running; then
                 break


### PR DESCRIPTION
Give consul time to install its HUP signal handler to avoid immediate shutdown when invoked via knife ssh, fixes #125.