### PR TITLE
Force-kill on /etc/init.d/consul stop. Fixes #128

### DIFF
--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -64,6 +64,10 @@ case "$1" in
         echo
 
         if is_running; then
+          kill -9 `get_pid`
+        fi
+
+        if is_running; then
             echo "$NAME not stopped; may still be shutting down or shutdown may have failed"
             exit 1
         else


### PR DESCRIPTION
In some conditions (I'm seeing it on a new node bootstrap when chef wants to start and then restart consul), consul does not come down in time for the init script. This change kill -9's the process if it hasn't come down within the 10s window.