### PR TITLE
Set GOMAXPROCS for runit services

### DIFF
--- a/templates/default/sv-consul-run.erb
+++ b/templates/default/sv-consul-run.erb
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+GOMAXPROCS=<%= node['cpu']['total'] %>
+
 exec 2>&1
 exec <%= node['runit']['chpst_bin'] %> \
   -u <%= node['consul']['service_user'] %>:<%= node['consul']['service_group'] %> \


### PR DESCRIPTION
GOMAXPROCS wasn't set for runit services as it was for init.d services; this changes corrects that oversight.