### PR TITLE
Add support for Consul 0.5.0 and Atlas auto-join

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,3 +49,11 @@ suites:
       consul:
         service_mode: cluster
         bootstrap_expect: 1
+  - name: atlas
+    run_list:
+      - recipe[consul::default]
+    attributes:
+      consul:
+        atlas_autojoin: true
+        atlas_cluster: <%= ENV.fetch('ATLAS_CLUSTER', 'example/cluster') %>
+        atlas_token: <%= ENV.fetch('ATLAS_TOKEN', 'NOT_REAL') %>

--- a/README.md
+++ b/README.md
@@ -256,6 +256,30 @@ Installs and configures [Consul][1] client, server and UI.
     <td>This provides the address of a statsd instance (UDP).</td>
     <td><tt>nil</tt></td>
   </tr>
+  <tr>
+    <td><tt>['consul']['atlas_autojoin']</tt></td>
+    <td>Boolean</td>
+    <td>
+        Determines whether Consul attempts to auto-join the cluster provided by <tt>atlas_cluster</tt> using the value of <tt>atlas_token</tt>
+    </td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['atlas_cluster']</tt></td>
+    <td>String</td>
+    <td>
+        Name of Atlas cluster to auto-join
+    </td>
+    <td><tt>nil</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['atlas_token']</tt></td>
+    <td>String</td>
+    <td>
+        API token used for Atlas integration
+    </td>
+    <td><tt>nil</tt></td>
+  </tr>
 </table>
 
 ### Databag Attributes (optional)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -118,3 +118,8 @@ default['consul']['client_interface'] = nil
 default['consul']['client_addr']  = '0.0.0.0'
 default['consul']['serve_ui']     = false
 default['consul']['extra_params'] = {}
+
+# Atlas support
+default['consul']['atlas_autojoin'] = false
+default['consul']['atlas_cluster'] = nil
+default['consul']['atlas_token'] = nil

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -177,6 +177,17 @@ if node.consul.verify_incoming || node.consul.verify_outgoing
   end
 end
 
+# Atlas integration
+if node.consul.atlas_autojoin or node.consul.atlas_token
+  cluster = node.consul.atlas_cluster
+  token = node.consul.atlas_token
+  raise "atlas_cluster is empty or nil" if cluster.empty? or cluster.nil?
+  raise "atlas_token is empty or nil" if token.empty? or token.nil?
+  service_config['atlas_infrastructure'] = cluster
+  service_config['atlas_join'] = node.consul.atlas_autojoin
+  service_config['atlas_token'] = token
+end
+
 consul_config_filename = File.join(node['consul']['config_dir'], 'default.json')
 
 file consul_config_filename do

--- a/test/integration/atlas/serverspec/localhost/atlas_spec.rb
+++ b/test/integration/atlas/serverspec/localhost/atlas_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe command('which consul') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match '/usr/local/bin/consul' }
+end
+
+describe service('consul') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe file('/etc/consul.d') do
+  it { should be_directory }
+end
+
+describe command('grep atlas /etc/consul.d/default.json') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match %r{"atlas_infrastructure":\s"([^"]*)"} }
+  its(:stdout) { should match %r{"atlas_join":\s(true|false)} }
+  its(:stdout) { should match %r{"atlas_token":\s"([^"]*)"} }
+end

--- a/test/integration/atlas/serverspec/spec_helper.rb
+++ b/test/integration/atlas/serverspec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.path = '/usr/local/bin:/sbin:/bin:/usr/bin'
+end


### PR DESCRIPTION
Commit adfa120174c85a3c61d6ab6be9ca390f3af05af2 can probably be ignored from mainline. I took a glance at rebasing this off of `develop` branch,
but it seems like it's in the middle of a sizeable rewrite.

Please keep or discard as much as you the maintainers find useful, in light of #126 etc.