### PR TITLE
Make service enable conditional on an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,6 +44,7 @@ default['consul']['checksums']      = {
 default['consul']['source_revision'] = 'master'
 
 # Service attributes
+default['consul']['enable'] = true
 default['consul']['service_mode'] = 'bootstrap'
 default['consul']['retry_on_join'] = false
 

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -209,24 +209,46 @@ when 'init'
     notifies :restart, 'service[consul]', :immediately
   end
 
-  service 'consul' do
-    provider Chef::Provider::Service::Upstart if platform?("ubuntu")
-    supports status: true, restart: true, reload: true
-    action [:enable, :start]
-    subscribes :restart, "file[#{consul_config_filename}"
-    subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
+  if node['consul']['enable']
+    service 'consul' do
+      provider Chef::Provider::Service::Upstart if platform?("ubuntu")
+      supports status: true, restart: true, reload: true
+      action [:enable, :start]
+      subscribes :restart, "file[#{consul_config_filename}"
+      subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
+    end
+  else
+    service 'consul' do
+       supports status: true, restart: true, reload: true
+       action :disable
+    end
   end
 when 'runit'
-  runit_service 'consul' do
-    supports status: true, restart: true, reload: true
-    action [:enable, :start]
-    subscribes :restart, "file[#{consul_config_filename}]"
-    subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
-    log true
-  end
+  if node['consul']['enable']
+    runit_service 'consul' do
+      supports status: true, restart: true, reload: true
+      action [:enable, :start]
+      subscribes :restart, "file[#{consul_config_filename}]"
+      subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
+      log true
+    end
 
-  service 'consul' do
-    supports status: true, restart: true, reload: true
-    reload_command "'#{node['runit']['sv_bin']}' hup consul"
+    service 'consul' do
+      supports status: true, restart: true, reload: true
+      reload_command "'#{node['runit']['sv_bin']}' hup consul"
+    end
+  else
+    runit_service 'consul' do
+      supports status: true, restart: true, reload: true
+      action :create
+      log true
+    end
+
+    # ignore restart notifications or sv errors will break run
+    service 'consul' do
+      supports status: true, restart: true, reload: true
+      reload_command "true"
+      restart_command "true"
+    end
   end
 end


### PR DESCRIPTION
In some workflows (e.g. 'image baking') you may want a chef run that
installs consul, but to delay the actual start until a later run

I only tested the runit path (and that on the [consul-0.5.0-conditional](https://github.com/donaldguy/consul-cookbook/tree/consul-0.5.0-conditional) branch but thought I'd get eyes on it anyway