### PR TITLE
Add support for HTTP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,14 +419,24 @@ the `consul::ui` recipe in your node's `run_list`.
       notifies :reload, 'service[consul]'
     end
 
-##### Adding service with check
+##### Adding services with checks
 
-    consul_service_def 'voice1' do
+    consul_service_def "voice1' do
       port 5060
       tags ['_sip._udp']
       check(
         interval: '10s',
         script: 'echo ok'
+      )
+      notifies :reload, 'service[consul]'
+    end
+
+    consul_service_def 'server1' do
+      port 80
+      tags ['http']
+      check(
+        interval: '10s',
+        http: 'http://localhost:80'
       )
       notifies :reload, 'service[consul]'
     end

--- a/resources/check_def.rb
+++ b/resources/check_def.rb
@@ -23,6 +23,7 @@ default_action :create
 attribute :name, name_attribute: true, required: true, kind_of: String
 attribute :id, kind_of: String
 attribute :script, kind_of: String
+attribute :http, kind_of: String
 attribute :ttl, kind_of: String
 attribute :interval, kind_of: String
 attribute :notes, kind_of: String
@@ -48,6 +49,7 @@ def to_hash
   hash[:check][:id] = id unless id.nil?
   hash[:check][:script] = script unless script.nil?
   hash[:check][:ttl] = ttl unless ttl.nil?
+  hash[:check][:http] = http unless http.nil?
   hash[:check][:interval] = interval unless interval.nil?
   hash[:check][:notes] = notes unless notes.nil?
   hash

--- a/resources/service_def.rb
+++ b/resources/service_def.rb
@@ -25,7 +25,7 @@ attribute :id, kind_of: String
 attribute :port, kind_of: Integer
 attribute :tags, kind_of: Array, default: nil
 attribute :check, kind_of: Hash, default: nil, callbacks: {
-  'Checks must be a hash containing either a `:ttl` key/value or a `:script` and `:interval` key/value' => ->(check) do
+  'Checks must be a hash containing either a `:ttl` key/value or a `:script/:http` and `:interval` key/value' => ->(check) do
     Chef::Resource::ConsulServiceDef.validate_check(check)
   end
 }
@@ -35,11 +35,15 @@ def self.validate_check(check)
     return false
   end
 
-  if check.key?(:ttl) && (!check.key?(:interval) && !check.key?(:script))
+  if check.key?(:ttl) && ( [:interval, :script, :http].none?{|key| check.key?(key)} )
     return true
   end
 
   if check.key?(:interval) && check.key?(:script)
+    return true
+  end
+
+  if check.key?(:interval) && check.key?(:http)
     return true
   end
 

--- a/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_create.rb
+++ b/spec/fixtures/cookbooks/consul_spec/recipes/check_def_with_id_create.rb
@@ -4,5 +4,6 @@ consul_check_def "dummy name" do
   script "curl http://localhost:8888/health"
   interval "10s"
   ttl "50s"
+  http "http://localhost:8888/health"
   notes "Blahblah"
 end

--- a/spec/unit/resources/check_def_spec.rb
+++ b/spec/unit/resources/check_def_spec.rb
@@ -13,8 +13,13 @@ describe_resource "consul_check_def" do
       end
 
       it "register the check" do
-        ['"name": "dummy name"', '"id": "uniqueid"', '"script": "curl http://localhost:8888/health"',
-            '"interval": "10s"', '"ttl": "50s"', '"notes": "Blahblah"'].each do |content|
+        ['"name": "dummy name"',
+         '"id": "uniqueid"',
+         '"script": "curl http://localhost:8888/health"',
+         '"http": "http://localhost:8888/health"',
+         '"interval": "10s"',
+         '"ttl": "50s"',
+         '"notes": "Blahblah"'].each do |content|
           expect(chef_run).to render_file(check_def_path)
             .with_content(content)
         end


### PR DESCRIPTION
Newer versions of Consul support built-in HTTP+interval checks (https://consul.io/docs/agent/checks.html). This adds support for `http` as an alternative to `script` in the service_def LWRP so we can do e.g.

```ruby
consul_service_def "service" do
  check(
    id: "service",
    name: "service on port 80",
    http: "http://localhost:80/",
    interval: "10s",
    timeout: "1s"
  )
  notifies :reload, "service[consul]"
end
```