### PR TITLE
Adds systemd init style (support for arch platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,19 @@ Installs and configures [Consul][1] client, server and UI.
   <tr>
     <td><tt>['consul']['init_style']</tt></td>
     <td>String</td>
-    <td>Service init mode for running consul as: init or runit</td>
+    <td>Service init mode for running consul as: init,  runit or systemd</td>
     <td><tt>init</tt></td>
   </tr>
   <tr>
     <td><tt>['consul']['service_user']</tt></td>
     <td>String</td>
-    <td>For runit service: run consul as this user (init uses 'root')</td>
+    <td>For runit/systemd service: run consul as this user (init uses 'root')</td>
     <td><tt>consul</tt></td>
   </tr>
   <tr>
     <td><tt>['consul']['service_group']</tt></td>
     <td>String</td>
-    <td>For runit service: run consul as this group (init uses 'root')</td>
+    <td>For runit/systemd service: run consul as this group (init uses 'root')</td>
     <td><tt>consul</tt></td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Installs and configures [Consul][1] client, server and UI.
 - CentOS 5.10, 6.5, 7.0
 - RHEL 5.10, 6.5, 7.0
 - Ubuntu 10.04, 12.04, 14.04
+- Arch Linux
 
 ## Attributes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,10 +61,10 @@ else
 end
 
 default['consul']['servers'] = []
-default['consul']['init_style'] = 'init'   # 'init', 'runit'
+default['consul']['init_style'] = 'init'   # 'init', 'runit', 'systemd'
 
 case node['consul']['init_style']
-when 'runit'
+when 'runit' || 'systemd'
   default['consul']['service_user'] = 'consul'
   default['consul']['service_group'] = 'consul'
 else

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,6 +21,8 @@ supports 'ubuntu', '= 10.04'
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
+supports 'arch'
+
 depends 'libarchive'
 depends 'chef-provisioning'
 depends 'golang', '~> 1.4'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -229,4 +229,17 @@ when 'runit'
     supports status: true, restart: true, reload: true
     reload_command "'#{node['runit']['sv_bin']}' hup consul"
   end
+when 'systemd'
+  template '/etc/systemd/system/consul.service' do
+    source 'consul-systemd.erb'
+    mode 0755
+    notifies :restart, 'service[consul]', :immediately
+  end
+
+  service 'consul' do
+    supports status: true, restart: true, reload: true
+    action [:enable, :start]
+    subscribes :restart, "file[#{consul_config_filename}]"
+    subscribes :restart, "link[#{Chef::Consul.active_binary(node)}]"
+  end
 end

--- a/templates/default/consul-systemd.erb
+++ b/templates/default/consul-systemd.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=Consul Agent
+Wants=basic.target
+After=basic.target network.target
+
+[Service]
+User=<%= node['consul']['service_user'] %>
+Group=<%= node['consul']['service_group'] %>
+ExecStart=<%= Chef::Consul.active_binary(node) %> agent \
+  -config-dir <%= node['consul']['config_dir'] %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=42s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I have added a systemd unit file which can be used by setting `node[consul][init_style] = 'systemd'`. I have tested this init style on Arch Linux and everything seems to work as expected. It is probably best to use this init style as the default on `platform_family?("arch")`.

I apologize for not adding the platform to `.kitchen.yml`, but I do not have Vagrant set up at the moment, so I must leave that up to someone else.