### PR TITLE
Lock libarchive cookbook version to maintain Chef 11 compatibility

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ supports 'arch'
 
 recommends 'chef-provisioning'
 
-depends 'libarchive'
+depends 'libarchive', "~> 0.4.0"
 depends 'golang', '~> 1.4'
 depends 'runit'
 depends 'yum-repoforge'


### PR DESCRIPTION
See: reset/libarchive-cookbook#7