### PR TITLE
Fix SysVinit script

### DIFF
--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -41,7 +41,7 @@ case "$1" in
     else
         echo "Starting $NAME"
         exec 2> >(while IFS= read -r line; do logger -t consul "$line"; done)
-        "${CMD[@]}" >> "$LOGFILE" &
+        ${CMD[@]} >> "$LOGFILE" &
         echo $! > "$PIDFILE"
         if ! is_running; then
             echo "Unable to start $NAME, see $LOGFILE"


### PR DESCRIPTION
This fixes #150. 

In 77b2fd9, a change was introduced which uses array expansion to execute the consul agent.

However, because the results of the expansion (including the arguments) are quoted, bash treats the entire string as a command without any word splitting, and tries to execute e.g., 

    /usr/local/bin/consul agent -config-dir /etc/consul.d

... which fails because that isn't a valid command.

As far as I can tell, this would break the SysV init script on all platforms which use it. (RHEL, Fedora, Amazon Linux, &c.) 