### PR TITLE
Bump default version mentioned in README.me 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Installs and configures [Consul][1] client, server and UI.
     <td><tt>['consul']['version']</tt></td>
     <td>String</td>
     <td>Version to install</td>
-    <td><tt>0.4.1</tt></td>
+    <td><tt>0.5.0</tt></td>
   </tr>
   <tr>
     <td><tt>['consul']['base_url']</tt></td>


### PR DESCRIPTION
This is a simple doc change to update the default version mentioned in the README to the version in 1f4b3bba5242feb06ef966a032faa8ac9df8f45c.