### PR TITLE
Ensure GOMAXPROCS is at least 2

### DIFF
--- a/templates/default/consul-sysconfig.erb
+++ b/templates/default/consul-sysconfig.erb
@@ -1,1 +1,1 @@
-GOMAXPROCS=<%= node['cpu']['total'] %>
+GOMAXPROCS=<%= [node['cpu']['total'], 2].max %>

--- a/templates/default/sv-consul-run.erb
+++ b/templates/default/sv-consul-run.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export GOMAXPROCS=<%= node['cpu']['total'] %>
+export GOMAXPROCS=<%= [node['cpu']['total'], 2].max %>
 
 exec 2>&1
 exec <%= node['runit']['chpst_bin'] %> \


### PR DESCRIPTION
This is a follow-up/rebase/rework of #118. Consul emits warnings if started with GOMAXPROCS set to 1, and as referenced in #118, the Consul developers seem to recommend having it set to at least 2.

There seem to be two commits, 5a926ac903465a6f965941f5433e171b8b0984f9 and 4f520365b24c392f5f2a09574420ca6f6c0bf1cf, that both does what this PR does. Is there a reason those two commits are no longer in master?