### PR TITLE
Be able to move the log file with an attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,7 @@ default['consul']['retry_on_join'] = false
 default['consul']['bootstrap_expect'] = 3
 default['consul']['data_dir'] = '/var/lib/consul'
 default['consul']['config_dir'] = '/etc/consul.d'
+default['consul']['logfile'] = '/var/log/consul.log'
 case node['platform_family']
 when 'debian'
   default['consul']['etc_config_dir'] = '/etc/default/consul'

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -210,6 +210,9 @@ when 'init'
   template init_file do
     source init_tmpl
     mode init_mode
+    variables(
+      consul_logfile: node['consul']['logfile']
+    )
     notifies :restart, 'service[consul]', :immediately
   end
 

--- a/templates/default/consul-init.erb
+++ b/templates/default/consul-init.erb
@@ -24,7 +24,7 @@ CMD="<%= Chef::Consul.active_binary(node) %> agent -config-dir <%= node['consul'
 NAME="consul"
 
 PIDFILE="/var/run/$NAME.pid"
-LOGFILE="/var/log/$NAME.log"
+LOGFILE="<%= @consul_logfile %>"
 
 get_pid() {
     cat "$PIDFILE"

--- a/templates/default/consul.conf.erb
+++ b/templates/default/consul.conf.erb
@@ -11,7 +11,7 @@ script
   fi
   export GOMAXPROCS=${GOMAXPROCS}
   CMD="<%= Chef::Consul.active_binary(node) %> agent -config-dir <%= node['consul']['config_dir'] %>"
-  LOGFILE="/var/log/consul.log"
+  LOGFILE="<%= @consul_logfile %>"
   exec $CMD >> "$LOGFILE"
 end script
 


### PR DESCRIPTION
Logrotate wouldn't rotate `/var/log/consul.log` because it complained about incorrect permissions on `/var/log`.

Moving the logfile was the best solution that I could find - this adds that capability easily.