### PR TITLE
Add packages install method.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,6 +27,19 @@ suites:
     attributes:
       consul:
         install_method: source
+  - name: packages
+    run_list:
+      - recipe[consul::default]
+    attributes:
+      consul:
+        datacenter: FortMeade
+        bind_interface: eth0
+        advertise_interface: eth0
+        encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
+        install_method: packages
+    excludes:
+      - centos-7.0
+      - centos-6.5
   - name: runit
     run_list:
       - recipe[consul::default]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['consul']['checksums']      = {
   '0.5.1_web_ui'       => 'ad883aa52e1c0136ab1492bbcedad1210235f26d59719fb6de3ef6464f1ff3b1',
 }
 default['consul']['source_revision'] = 'master'
+default['consul']['use_packagecloud_repo'] = true
 
 # Service attributes
 default['consul']['service_mode'] = 'bootstrap'

--- a/metadata.rb
+++ b/metadata.rb
@@ -26,3 +26,4 @@ depends 'libarchive', "~> 0.4.0"
 depends 'golang', '~> 1.4'
 depends 'runit'
 depends 'yum-repoforge'
+depends 'packagecloud'

--- a/recipes/install_packages.rb
+++ b/recipes/install_packages.rb
@@ -14,14 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# NOTE: This is only supported for Ubuntu 12.04LTS and 14.04LTS.
 
-case node['consul']['install_method']
-when 'binary'
-  include_recipe 'consul::install_binary'
-when 'source'
-  include_recipe 'consul::install_source'
-when 'packages'
-  include_recipe 'consul::install_packages'
-else
-  Chef::Application.fatal!("[consul::default] unknown install method, method=#{node['consul']['install_method']}")
+if node['consul']['use_packagecloud_repo']
+
+  packagecloud_repo "darron/consul" do
+    type "deb"
+  end
+
+  packagecloud_repo "darron/consul-webui" do
+    type "deb"
+  end
+
 end
+
+package 'consul'
+package 'consul-webui'
+
+include_recipe 'consul::_service'

--- a/test/integration/packages/serverspec/localhost/consul_spec.rb
+++ b/test/integration/packages/serverspec/localhost/consul_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe command('which consul') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match '/usr/local/bin/consul' }
+end
+
+describe service('consul') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe file('/etc/consul.d') do
+  it { should be_directory }
+end
+
+describe file('/var/lib/consul') do
+  it { should be_directory }
+end
+
+[8300, 8400, 8500, 8600].each do |p|
+  describe port(p) do
+    it { should be_listening }
+  end
+end
+
+describe command 'consul members -detailed' do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match %r{\balive\b} }
+  its(:stdout) { should match %r{\brole=consul\b} }
+  its(:stdout) { should match %r{\bbootstrap=1\b} }
+end
+
+describe 'config file attributes' do
+  context command 'consul members -detailed' do
+    its(:stdout) { should match %r{\bdc=fortmeade\b} }
+  end
+end
+
+eth0_ip = command("/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'").stdout.strip
+describe command("grep #{eth0_ip} /etc/consul.d/default.json") do
+  its(:exit_status) { should eq 0 }
+  # bind_addr should only be in the config if node[:consul][:bind_addr] is set
+  its(:stdout) { should match %r{"bind_addr":\s"#{eth0_ip}"}}
+  its(:stdout) { should match %r{"advertise_addr":\s"#{eth0_ip}"}}
+end
+
+describe command('grep encrypt /etc/consul.d/default.json') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match %r{"encrypt":\s"([^\"]*)"} }
+end
+
+describe file('/var/lib/consul/ui/index.html') do
+  it { should be_file }
+end

--- a/test/integration/packages/serverspec/spec_helper.rb
+++ b/test/integration/packages/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+RSpec.configure do |c|
+  c.path = '/usr/local/bin:/sbin:/bin:/usr/bin'
+end


### PR DESCRIPTION
This patch adds a way to install Consul from already created Debian packages.

It only works Ubuntu at the moment - but I'd be happy to include RPM packages if somebody would build and test them.

These packages are built from these sources:

https://github.com/darron/consul-build
https://github.com/darron/consul-webui-build

The TestKitchen `packages` suite passes all tests - I duplicated the `default` tests and added a single test from the `ui` suite.

Comments?