### PR TITLE
Don't try to create directories twice

### DIFF
--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -50,7 +50,7 @@ group "consul service group: #{consul_group}" do
 end
 
 # Create service directories
-consul_directories.each do |dirname|
+consul_directories.uniq.each do |dirname|
   directory dirname do
     owner consul_user
     group consul_group


### PR DESCRIPTION
Fixes this warning:
```
==> develop: [2015-05-27T08:36:22+00:00] WARN: Previous directory[/var/lib/consul]: /tmp/vagrant-chef-2/chef-solo-2/cookbooks/consul/recipes/_service.rb:54:in `block in from_file'
==> develop: [2015-05-27T08:36:22+00:00] WARN: Current  directory[/var/lib/consul]: /tmp/vagrant-chef-2/chef-solo-2/cookbooks/consul/recipes/_service.rb:54:in `block in from_file'
```