### PR TITLE
Adding GOMAXPROCS support for systemd.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -94,6 +94,7 @@ else
   default['consul']['service_user'] = 'root'
   default['consul']['service_group'] = 'root'
 end
+default['consul']['system_account'] = false
 
 default['consul']['ports'] = {
   'dns'      => 8600,

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -38,6 +38,7 @@ user "consul service user: #{consul_user}" do
   username consul_user
   home '/dev/null'
   shell '/bin/false'
+  system node['consul']['system_account']
   comment 'consul service user'
 end
 
@@ -46,6 +47,7 @@ group "consul service group: #{consul_group}" do
   not_if { consul_group == 'root' }
   group_name consul_group
   members consul_user
+  system node['consul']['system_account']
   append true
 end
 

--- a/recipes/_service.rb
+++ b/recipes/_service.rb
@@ -248,6 +248,12 @@ when 'runit'
     reload_command "'#{node['runit']['sv_bin']}' hup consul"
   end
 when 'systemd'
+  template node['consul']['etc_config_dir'] do
+    source 'consul-sysconfig.erb'
+    mode 0644
+    notifies :create, "template[/etc/systemd/system/consul.service]", :immediately
+  end
+
   template '/etc/systemd/system/consul.service' do
     source 'consul-systemd.erb'
     mode 0644

--- a/templates/default/consul-systemd.erb
+++ b/templates/default/consul-systemd.erb
@@ -6,12 +6,13 @@ After=basic.target network.target
 [Service]
 User=<%= node['consul']['service_user'] %>
 Group=<%= node['consul']['service_group'] %>
+EnvironmentFile=-<%= node['consul']['etc_config_dir'] %>
 ExecStart=<%= Chef::Consul.active_binary(node) %> agent \
   -config-dir <%= node['consul']['config_dir'] %>
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-RestartSec=42s
+RestartSec=15s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When using systemd it currently always uses the default GOMAXPROCS of 1.  This change follows the documentation at http://fedoraproject.org/wiki/Packaging%3aSystemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files