### PR TITLE
use node array to refer to variables

### DIFF
--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -180,13 +180,13 @@ if node.consul.verify_incoming || node.consul.verify_outgoing
 end
 
 # Atlas integration
-if node.consul.atlas_autojoin or node.consul.atlas_token
-  cluster = node.consul.atlas_cluster
-  token = node.consul.atlas_token
+if node['consul']['atlas_autojoin'] or node['consul']['atlas_token']
+  cluster = node['consul']['atlas_cluster']
+  token = node['consul']['atlas_token']
   raise "atlas_cluster is empty or nil" if cluster.empty? or cluster.nil?
   raise "atlas_token is empty or nil" if token.empty? or token.nil?
   service_config['atlas_infrastructure'] = cluster
-  service_config['atlas_join'] = node.consul.atlas_autojoin
+  service_config['atlas_join'] = node['consul']['atlas_autojoin']
   service_config['atlas_token'] = token
 end
 


### PR DESCRIPTION
I use this cookbook via the "include_recipe 'consul'" method as I include this in one of my "base-server" cookbooks.

When I try to pass atlas autojoin/cluster/token variables through my cookbook the variables are not picked up by consul. I had a look through the code and found that the variables were referenced via "node.consul.atlas_autojoin" rather than "node['consul']['atlas_autojoin']". I'm not sure if there was a particular reason for this but changing it like this means the variables are picked up correctly.

@shanesveller originally wrote this in https://github.com/johnbellone/consul-cookbook/pull/135 not sure if there was a reason you referenced the variables this way Shane so happy for commentary if there was a particular reason :)

Tests still pass correctly, though I'm not sure how to word a test to cover this particular case?

Thanks,
Craig