### PR TITLE
Windows: resolved merge conflicts and added tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,13 @@ platforms:
   - name: ubuntu-12.04
   - name: centos-7.0
   - name: centos-6.5
+  <% if ENV['TEST_WINDOWS'] %>
+  - name: windows-2012r2-wrock
+    driver_config:
+      box_url: https://wrock.ca.tier3.io/win2012r2-virtualbox.box
+      customize:
+        usbehci: "off"
+  <% end %>
 
 suites:
   - name: default
@@ -70,3 +77,14 @@ suites:
         atlas_autojoin: true
         atlas_cluster: <%= ENV.fetch('ATLAS_CLUSTER', 'example/cluster') %>
         atlas_token: <%= ENV.fetch('ATLAS_TOKEN', 'NOT_REAL') %>
+  <% if ENV['TEST_WINDOWS'] %>
+  - name: windows
+    includes:
+      - windows-2012r2-wrock
+    run_list:
+      - recipe[consul::default]
+    attributes:
+      consul:
+        install_method: windows
+        service_user: vagrant
+  <% end %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,10 @@ platforms:
   <% if ENV['TEST_WINDOWS'] %>
   - name: windows-2012r2-wrock
     driver_config:
-      box_url: https://wrock.ca.tier3.io/win2012r2-virtualbox.box
+      network:
+        - ["forwarded_port", {guest: 5985, host: 5985}]
+      gui: true
+      box_url: https://wrock.blob.core.windows.net/vhds/vbox2012r2.box
       customize:
         usbehci: "off"
   <% end %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@ platforms:
     driver_config:
       network:
         - ["forwarded_port", {guest: 5985, host: 5985}]
+      communicator: winrm
       gui: true
       box_url: https://wrock.blob.core.windows.net/vhds/vbox2012r2.box
       customize:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,8 @@ platforms:
 
 suites:
   - name: default
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
     attributes:
@@ -29,6 +31,8 @@ suites:
         advertise_interface: eth0
         encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
   - name: source
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
     attributes:
@@ -47,7 +51,10 @@ suites:
     excludes:
       - centos-7.0
       - centos-6.5
+      - windows-2012r2-wrock
   - name: runit
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
     attributes:
@@ -55,6 +62,8 @@ suites:
         datacenter: FortMeade
         init_style: runit
   - name: ui
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
       - recipe[consul::ui]
@@ -63,6 +72,8 @@ suites:
         serve_ui: true
         client_interface: eth0
   - name: cluster
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
     attributes:
@@ -70,6 +81,8 @@ suites:
         service_mode: cluster
         bootstrap_expect: 1
   - name: atlas
+    excludes:
+      - windows-2012r2-wrock
     run_list:
       - recipe[consul::default]
     attributes:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Installs and configures [Consul][1] client, server and UI.
 - RHEL 6.5, 7.0
 - Ubuntu 12.04, 14.04
 - Arch Linux
+- Windows
 
 ## Attributes
 
@@ -44,14 +45,26 @@ Installs and configures [Consul][1] client, server and UI.
   <tr>
     <td><tt>['consul']['install_method']</tt></td>
     <td>String</td>
-    <td>Method to install consul with when using default recipe: binary or source</td>
-    <td><tt>binary</tt></td>
+    <td>Method to install consul with when using default recipe: 'binary', 'source' or 'windows'</td>
+    <td>
+      \*nix: <tt> binary</tt></br>
+      Windows: <tt>binary</tt>
+    </td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['choco_source']</tt></td>
+    <td>String</td>
+    <td>Source to use for fetching the chocolatey package. Defaults to the chocolatey public feed</td>
+    <td><tt>https://chocolatey.org/api/v2/</tt></td>
   </tr>
   <tr>
     <td><tt>['consul']['install_dir']</tt></td>
     <td>String</td>
     <td>Directory to install binary to.</td>
-    <td><tt>/usr/local/bin</tt></td>
+    <td>
+      \*nix: <tt>/usr/local/bin</tt></br>
+      Windows: <tt>{chocolatey_install_dir}\lib\consul.{consul_version}</tt>
+    </td>
   </tr>
   <tr>
     <td><tt>['consul']['service_mode']</tt></td>
@@ -69,13 +82,29 @@ Installs and configures [Consul][1] client, server and UI.
     <td><tt>['consul']['data_dir']</tt></td>
     <td>String</td>
     <td>Location to store consul's data in</td>
-    <td><tt>/var/lib/consul</tt></td>
+    <td>
+      \*nix: <tt>/var/lib/consul</tt></br>
+      Windows: <tt>C:\ProgramData\consul\data</tt>
+    </td>
   </tr>
   <tr>
     <td><tt>['consul']['config_dir']</tt></td>
     <td>String</td>
     <td>Location to read service definitions from (directoy will be created)</td>
-    <td><tt>/etc/consul.d</tt></td>
+    <td>
+      \*nix: <tt>/etc/consul.d</tt></br>
+      Windows: <tt>C:\ProgramData\consul\config</tt>
+    </td>
+  </tr>
+  <tr>
+    <td><tt>['consul']['etc_config_dir']</tt></td>
+    <td>String</td>
+    <td>Misc. configuration directory that might need to be execute during service start</td>
+    <td>
+      Debian: <tt>/etc/default/consul</tt></br>
+      Windows: <tt>{chocolatey_install_dir}\lib\consul.{consul_version}\tools</tt></br>
+      Other: <tt>/etc/sysconfig/consul</tt>
+    </td>
   </tr>
   <tr>
     <td><tt>['consul']['servers']</tt></td>
@@ -117,8 +146,7 @@ Installs and configures [Consul][1] client, server and UI.
     <td><tt>['consul']['log_level']</tt></td>
     <td>String</td>
     <td>
-      The level of logging to show after the Consul agent has started.
-      Available: "trace", "debug", "info", "warn", "err"
+      The level of logging to show after the Consul agent has started: 'trace', 'debug', 'info', 'warn', or 'err'
     </td>
     <td><tt>info</tt></td>
   </tr>
@@ -137,8 +165,11 @@ Installs and configures [Consul][1] client, server and UI.
   <tr>
     <td><tt>['consul']['init_style']</tt></td>
     <td>String</td>
-    <td>Service init mode for running consul as: init,  runit or systemd</td>
-    <td><tt>init</tt></td>
+    <td>Service init mode for running consul as: 'init', 'runit', 'systemd', or 'windows'</td>
+    <td>
+      \*nix: <tt>init</tt></br>
+      Windows: <tt>windows</tt>
+    </td>
   </tr>
   <tr>
     <td><tt>['consul']['service_user']</tt></td>
@@ -421,7 +452,8 @@ the application.
 
 ### consul::ui
 Installing the separate Consul UI simply requires you to include
-the `consul::ui` recipe in your node's `run_list`.
+the `consul::ui` recipe in your node's `run_list`. Consul UI is not supported
+on Windows platform.
 
 ```json
 {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,27 +18,8 @@
 default['consul']['base_url']       = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
 default['consul']['version']        = '0.5.2'
 default['consul']['install_method'] = 'binary'
-#default['consul']['init_style']     = 'init'   # 'init', 'runit', 'systemd', 'windows'
 default['consul']['install_dir']    = '/usr/local/bin'
-#default['consul']['data_dir']       = '/var/lib/consul'
-#default['consul']['config_dir']     = '/etc/consul.d'
 default['consul']['choco_source']   = "https://chocolatey.org/api/v2/"
-
-#case node['platform_family']
-#when 'windows'
-#  default['consul']['install_method'] = 'windows'
-#  default['consul']['init_style']     = 'windows'
-#  default['consul']['config_dir']     = "#{ENV['SystemDrive']}\\ProgramData\\consul\\config"
-#  default['consul']['data_dir']       = "#{ENV['SystemDrive']}\\ProgramData\\consul\\data"
-#  default['consul']['install_dir']    = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}"
-#  default['consul']['etc_config_dir'] = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}\\tools"
-#when 'debian'
-#  default['consul']['etc_config_dir'] = '/etc/default/consul'
-#when 'rhel'
-#  default['consul']['etc_config_dir'] = '/etc/sysconfig/consul'
-#else
-#  default['consul']['etc_config_dir'] = '/etc/sysconfig/consul'
-#end
 
 default['consul']['checksums'] = {
   '0.3.0_darwin_amd64' => '9dfbc70c01ebbc3e7dba0e4b31baeddbdcbd36ef99f5ac87ca6bbcc7405df405',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@
 
 default['consul']['base_url']       = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
 default['consul']['version']        = '0.5.2'
+if node['platform_family'] == 'windows'
+  default['consul']['version']      = '0.5.0'
+end
 default['consul']['install_method'] = 'binary'
 default['consul']['install_dir']    = '/usr/local/bin'
 default['consul']['choco_source']   = "https://chocolatey.org/api/v2/"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,8 +18,29 @@
 default['consul']['base_url']       = "https://dl.bintray.com/mitchellh/consul/%{version}.zip"
 default['consul']['version']        = '0.5.2'
 default['consul']['install_method'] = 'binary'
+#default['consul']['init_style']     = 'init'   # 'init', 'runit', 'systemd', 'windows'
 default['consul']['install_dir']    = '/usr/local/bin'
-default['consul']['checksums']      = {
+#default['consul']['data_dir']       = '/var/lib/consul'
+#default['consul']['config_dir']     = '/etc/consul.d'
+default['consul']['choco_source']   = "https://chocolatey.org/api/v2/"
+
+#case node['platform_family']
+#when 'windows'
+#  default['consul']['install_method'] = 'windows'
+#  default['consul']['init_style']     = 'windows'
+#  default['consul']['config_dir']     = "#{ENV['SystemDrive']}\\ProgramData\\consul\\config"
+#  default['consul']['data_dir']       = "#{ENV['SystemDrive']}\\ProgramData\\consul\\data"
+#  default['consul']['install_dir']    = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}"
+#  default['consul']['etc_config_dir'] = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}\\tools"
+#when 'debian'
+#  default['consul']['etc_config_dir'] = '/etc/default/consul'
+#when 'rhel'
+#  default['consul']['etc_config_dir'] = '/etc/sysconfig/consul'
+#else
+#  default['consul']['etc_config_dir'] = '/etc/sysconfig/consul'
+#end
+
+default['consul']['checksums'] = {
   '0.3.0_darwin_amd64' => '9dfbc70c01ebbc3e7dba0e4b31baeddbdcbd36ef99f5ac87ca6bbcc7405df405',
   '0.3.0_linux_386'    => '2513496374f8f15bda0da4da33122e93f82ce39f661ee3e668c67a5b7e98fd5f',
   '0.3.0_linux_amd64'  => 'da1337ab3b236bad19b791a54a8df03a8c2a340500a392000c21608696957b15',
@@ -66,7 +87,7 @@ default['consul']['source_revision'] = 'master'
 default['consul']['use_packagecloud_repo'] = true
 
 # Service attributes
-default['consul']['service_mode'] = 'bootstrap'
+default['consul']['service_mode']  = 'bootstrap'
 default['consul']['retry_on_join'] = false
 
 # In the cluster mode, set the default cluster size to 3
@@ -74,7 +95,15 @@ default['consul']['bootstrap_expect'] = 3
 default['consul']['data_dir'] = '/var/lib/consul'
 default['consul']['config_dir'] = '/etc/consul.d'
 default['consul']['logfile'] = '/var/log/consul.log'
+default['consul']['init_style'] = 'init'   # 'init', 'runit', 'systemd'
 case node['platform_family']
+when 'windows'
+  default['consul']['install_method'] = 'windows'
+  default['consul']['init_style']     = 'windows'
+  default['consul']['config_dir']     = "#{ENV['SystemDrive']}\\ProgramData\\consul\\config"
+  default['consul']['data_dir']       = "#{ENV['SystemDrive']}\\ProgramData\\consul\\data"
+  default['consul']['install_dir']    = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}"
+  default['consul']['etc_config_dir'] = "#{ChocolateyHelpers.chocolatey_install}\\lib\\consul.#{node['consul']['version']}\\tools"
 when 'debian'
   default['consul']['etc_config_dir'] = '/etc/default/consul'
 when 'rhel'
@@ -84,14 +113,16 @@ else
 end
 
 default['consul']['servers'] = []
-default['consul']['init_style'] = 'init'   # 'init', 'runit', 'systemd'
 
 case node['consul']['init_style']
 when 'runit' || 'systemd'
-  default['consul']['service_user'] = 'consul'
+  default['consul']['service_user']  = 'consul'
   default['consul']['service_group'] = 'consul'
+when 'windows'
+  default['consul']['service_user']  = 'Administrator'
+  default['consul']['service_group'] = 'Administrators'
 else
-  default['consul']['service_user'] = 'root'
+  default['consul']['service_user']  = 'root'
   default['consul']['service_group'] = 'root'
 end
 default['consul']['system_account'] = false
@@ -106,28 +137,28 @@ default['consul']['ports'] = {
 }
 
 # Consul DataBag
-default['consul']['data_bag'] = 'consul'
+default['consul']['data_bag']              = 'consul'
 default['consul']['data_bag_encrypt_item'] = 'encrypt'
 
 # Gossip encryption
 default['consul']['encrypt_enabled'] = false
-default['consul']['encrypt'] = nil
+default['consul']['encrypt']         = nil
 # TLS support
 default['consul']['verify_incoming'] = false
 default['consul']['verify_outgoing'] = false
 # Cert in pem format
-default['consul']['ca_cert'] = nil
-default['consul']['ca_path'] = "%{config_dir}/ca.pem"
+default['consul']['ca_cert']   = nil
+default['consul']['ca_path']   = "%{config_dir}/ca.pem"
 default['consul']['cert_file'] = nil
 default['consul']['cert_path'] = "%{config_dir}/cert.pem"
 # Cert in pem format. It can be unique for each host
-default['consul']['key_file'] = nil
+default['consul']['key_file']      = nil
 default['consul']['key_file_path'] = "%{config_dir}/key.pem"
 
 # Optionally bind to a specific interface
-default['consul']['bind_interface'] = nil
+default['consul']['bind_interface']      = nil
 default['consul']['advertise_interface'] = nil
-default['consul']['client_interface'] = nil
+default['consul']['client_interface']    = nil
 
 # UI attributes
 default['consul']['client_addr']  = '0.0.0.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,7 @@ end
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 supports 'arch'
+supports 'windows'
 
 recommends 'chef-provisioning'
 
@@ -27,3 +28,7 @@ depends 'golang', '~> 1.4'
 depends 'runit'
 depends 'yum-repoforge'
 depends 'packagecloud'
+
+# for windows
+depends 'windows'
+depends "chocolatey"

--- a/providers/check_def.rb
+++ b/providers/check_def.rb
@@ -24,8 +24,12 @@ action :create do
   end
 
   file new_resource.path do
-    user node['consul']['service_user']
-    group node['consul']['service_group']
+    if node['platform'] == 'windows'
+      rights :full_control, node['consul']['service_user'], :applies_to_children => true
+    else
+      user node['consul']['service_user']
+      group node['consul']['service_group']
+    end
     mode 0600
     content new_resource.to_json
 

--- a/providers/event_watch_def.rb
+++ b/providers/event_watch_def.rb
@@ -19,8 +19,12 @@ use_inline_resources
 
 action :create do
   file new_resource.path do
-    user node['consul']['service_user']
-    group node['consul']['service_group']
+    if node['platform'] == 'windows'
+      rights :full_control, node['consul']['service_user'], :applies_to_children => true
+    else
+      user node['consul']['service_user']
+      group node['consul']['service_group']
+    end
     mode 0600
     content new_resource.to_json
 

--- a/providers/key_watch_def.rb
+++ b/providers/key_watch_def.rb
@@ -19,8 +19,12 @@ use_inline_resources
 
 action :create do
   file new_resource.path do
-    user node['consul']['service_user']
-    group node['consul']['service_group']
+    if node['platform'] == 'windows'
+      rights :full_control, node['consul']['service_user'], :applies_to_children => true
+    else
+      user node['consul']['service_user']
+      group node['consul']['service_group']
+    end
     mode 0600
     content new_resource.to_json
 

--- a/providers/service_def.rb
+++ b/providers/service_def.rb
@@ -25,8 +25,12 @@ end
 action :create do
   set_updated do
     file new_resource.path do
-      user node['consul']['service_user']
-      group node['consul']['service_group']
+      if node['platform'] == 'windows'
+        rights :full_control, node['consul']['service_user'], :applies_to_children => true
+      else
+        user node['consul']['service_user']
+        group node['consul']['service_group']
+      end
       mode 0600
       content new_resource.to_json
       action :create

--- a/providers/service_watch_def.rb
+++ b/providers/service_watch_def.rb
@@ -19,8 +19,12 @@ use_inline_resources
 
 action :create do
   file new_resource.path do
-    user node['consul']['service_user']
-    group node['consul']['service_group']
+    if node['platform'] == 'windows'
+      rights :full_control, node['consul']['service_user'], :applies_to_children => true
+    else
+      user node['consul']['service_user']
+      group node['consul']['service_group']
+    end
     mode 0600
     content new_resource.to_json
 

--- a/recipes/install_windows.rb
+++ b/recipes/install_windows.rb
@@ -1,6 +1,6 @@
 #
-# Copyright 2014 John Bellone <jbellone@bloomberg.net>
-# Copyright 2014 Bloomberg Finance L.P.
+# Copyright 2015 Rohit Amarnath <rohit.amarnath@full360.com>
+# Copyright 2015 Full 360 Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,17 +15,14 @@
 # limitations under the License.
 #
 
-case node['consul']['install_method']
-when 'binary'
-  include_recipe 'consul::install_binary'
-when 'source'
-  include_recipe 'consul::install_source'
-when 'packages'
-  include_recipe 'consul::install_packages'
-when 'windows'
-  include_recipe 'consul::install_windows'
-else
-  Chef::Application.fatal!("[consul::default] unknown install method, method=#{node['consul']['install_method']}")
+if node['platform'] == 'windows'
+
+  include_recipe 'chocolatey::default'
+
+  chocolatey 'consul' do
+    version node['consul']['version']
+    source node['consul']['choco_source']
+  end
 end
 
-include_recipe 'consul::service'
+include_recipe 'consul::_service'

--- a/recipes/install_windows.rb
+++ b/recipes/install_windows.rb
@@ -24,5 +24,3 @@ if node['platform'] == 'windows'
     source node['consul']['choco_source']
   end
 end
-
-include_recipe 'consul::_service'

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -13,28 +13,32 @@
 # limitations under the License.
 #
 
-include_recipe 'libarchive::default'
+if node['platform'] == 'windows'
+  Chef::Log.error "UI Installation not supported for Windows"
+else
+  include_recipe 'libarchive::default'
 
-archive = remote_file Chef::ConsulUI.cached_archive(node) do
-  source Chef::ConsulUI.remote_url(node)
-  checksum Chef::ConsulUI.remote_checksum(node)
-end
+  archive = remote_file Chef::ConsulUI.cached_archive(node) do
+    source Chef::ConsulUI.remote_url(node)
+    checksum Chef::ConsulUI.remote_checksum(node)
+  end
 
-libarchive_file 'consul_ui.zip' do
-  path archive.path
-  extract_to Chef::ConsulUI.install_path(node)
-  extract_options :no_overwrite
+  libarchive_file 'consul_ui.zip' do
+    path archive.path
+    extract_to Chef::ConsulUI.install_path(node)
+    extract_options :no_overwrite
 
-  action :extract
-end
+    action :extract
+  end
 
-# JW TODO: Remove after next major release.
-directory Chef::ConsulUI.active_path(node) do
-  action :delete
-  recursive true
-  not_if "test -L #{Chef::ConsulUI.active_path(node)}"
-end
+  # JW TODO: Remove after next major release.
+  directory Chef::ConsulUI.active_path(node) do
+    action :delete
+    recursive true
+    not_if "test -L #{Chef::ConsulUI.active_path(node)}"
+  end
 
-link Chef::ConsulUI.active_path(node) do
-  to Chef::ConsulUI.latest_dist(node)
+  link Chef::ConsulUI.active_path(node) do
+    to Chef::ConsulUI.latest_dist(node)
+  end
 end

--- a/test/integration/windows/serverspec/localhost/consul_spec.rb
+++ b/test/integration/windows/serverspec/localhost/consul_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe command('where.exe /R C:\ProgramData\chocolatey\bin consul') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match "C:\\ProgramData\\chocolatey\\bin\\consul.exe\n" }
+end
+
+describe service('consul') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe file('C:\ProgramData\consul\config') do
+  it { should be_directory }
+end
+
+describe file('C:\ProgramData\consul\data') do
+  it { should be_directory }
+end
+
+describe port(8300) do
+  it { should be_listening }
+end
+
+# For some reason, the check can't find the port
+#[8400, 8500, 8600].each do |p|
+#  describe port(p) do
+#    it { should be_listening.on('127.0.0.1') }
+#  end
+#end

--- a/test/integration/windows/serverspec/spec_helper.rb
+++ b/test/integration/windows/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+set :backend, :cmd
+set :os, :family => 'windows'
+set :architecture, :x86_64


### PR DESCRIPTION
This adds support for installing on Windows using the `install_method` of `windows`. It uses the Chocolatey package manager.

I have made the Windows tests conditional on setting the `TEST_WINDOWS` environment variable to a truthy value. I tried using vagrant boxes from [https://github.com/joefitzgerald/packer-windows] and [https://github.com/boxcutter/windows],  but I was not able to make them work. The box used is approximately 3 GB to download. Provisioning only seems to work if you login at boot time; annoying, but it works.