### PR TITLE
Adding open files configuration for Upstart.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -105,6 +105,10 @@ default['consul']['ports'] = {
   "server"   => 8300,
 }
 
+# Ubuntu Upstart Open Files Limit
+default['consul']['files_soft_limit'] = 2048
+default['consul']['files_hard_limit'] = 4096
+
 # Consul DataBag
 default['consul']['data_bag'] = 'consul'
 default['consul']['data_bag_encrypt_item'] = 'encrypt'

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -231,7 +231,9 @@ when 'init'
     mode init_mode
     variables(
       consul_logfile: node['consul']['logfile'],
-      startup_sleep: node['consul']['startup_sleep']
+      startup_sleep: node['consul']['startup_sleep'],
+      soft_limit: node['consul']['files_soft_limit'],
+      hard_limit: node['consul']['files_hard_limit']
     )
     notifies :restart, 'service[consul]', :immediately
   end

--- a/templates/default/consul.conf.erb
+++ b/templates/default/consul.conf.erb
@@ -5,6 +5,9 @@ emits consul-up
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+# set max open files
+limit nofile <%= @soft_limit %> <%= @hard_limit %>
+
 script
   if [ -f <%= node['consul']['etc_config_dir'] %> ]; then
     . <%= node['consul']['etc_config_dir'] %>


### PR DESCRIPTION
In our environment, we're getting to the place where Consul doesn't have enough open files by default.

Upstart doesn't respect `/etc/security/limits.conf`: https://bugs.launchpad.net/ubuntu/+source/upstart/+bug/938669

So you have to add it manually to the `/etc/init/consul.conf`: http://upstart.ubuntu.com/wiki/Stanzas#limit

This seemed like the best way to do it given the cookbook creates those files.