### PR TITLE
resource and library to handle acls

### DIFF
--- a/libraries/consul_client.rb
+++ b/libraries/consul_client.rb
@@ -1,0 +1,67 @@
+class Chef
+  module Consul
+    class Client
+      def initialize(host ,port, token)
+        require 'net/http'
+        require 'json'
+        @host = host || '127.0.0.1'
+        @port = port || '8500'
+        @base_uri = "http://#{@host}:#{@port}/v1"
+        @token = token || nil
+      end
+
+      def http_request(method, uri, data = nil)
+        method = {
+          get: Net::HTTP::Get,
+          put: Net::HTTP::Put,
+        }.fetch(method)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = method.new(uri.request_uri)
+        request.body = data.to_json if data
+        response = http.request(request)
+
+        if response.code.to_i == 403
+          raise "Authentication Error"
+        elsif response.code.to_i != 200
+          raise "Failed to process request #{uri} #{response.inspect}"
+        end
+        response
+      end
+
+      def get(request_uri)
+        url = "#{@base_uri}/#{request_uri}?token=#{@token}"
+        uri = URI.parse(url)
+        response = http_request(:get, uri)
+        JSON.parse("[#{response.body}]")[0]
+      end
+
+      def put(request_uri, data = nil)
+        #url = @base_uri + request_uri + '?token=' + @token
+        url = "#{@base_uri}/#{request_uri}?token=#{@token}"
+        uri = URI.parse(url)
+        response = http_request(:put, uri, data)
+        JSON.parse("[#{response.body}]")[0]
+      end
+
+      def get_acl_by_name(resource)
+        acls = get('acl/list')
+        acls.select { |acl| acl['Name'] == resource }[0]
+      end
+
+      def get_acl_by_ID(resource)
+        acls = get("acl/info/#{resource}")
+        acls.select { |acl| acl['ID'] == resource }[0]
+      end
+
+      def create_acl(data)
+        put("acl/create", data)
+      end
+
+      def delete_acl(resource)
+        id = get_acl_by_name(resource)['ID']
+        put("acl/destroy/#{id}")
+      end
+    end
+  end
+end

--- a/providers/acl_def.rb
+++ b/providers/acl_def.rb
@@ -1,0 +1,45 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use_inline_resources if defined? use_inline_resources
+
+action :create do
+  ruby_block new_resource do
+    data = {}
+    data['Name'] = new_resource.name
+    data['Type'] = new_resource.type
+    data['Rules'] = new_resource.rules
+    data['ID'] = new_resource.id unless new_resource.id.nil?
+    block { client.create_acl(data) }
+    only_if { !@current_resource || update_required? }
+  end
+end
+
+action :delete do
+  ruby_block new_resource do
+    block { @client.delete_acl(@new_resource.name) }
+    only_if { @current_resource }
+  end
+end
+
+def client
+  @client ||= Chef::Consul::Client.new(nil,node['consul']['ports']['http'],node['consul']['acl_master_token'])
+end
+
+def load_current_resource
+  @current_resource = client.get_acl_by_name(@new_resource.name)
+end
+
+def update_required?
+  @current_resource['Rules'] == @new_resource['Rules'] && @current_resource['Type'] == @new_resource['Type']
+end

--- a/resources/acl_def.rb
+++ b/resources/acl_def.rb
@@ -1,0 +1,9 @@
+require 'json'
+
+actions :create, :delete
+default_action :create
+
+attribute :name, name_attribute: true, required: true, kind_of: String
+attribute :rules, kind_of: String
+attribute :id, kind_of: String
+attribute :type, kind_of: String, default: "client", required: true


### PR DESCRIPTION
A lib to manage acls on a consul server using the HTTP api and the resources that use it.

The plan is to later add more resources/providers that use that same consul_client.rb lib instead of writing files.