### PR TITLE
Remove references to "quicks_mode" in JSON generation

### DIFF
--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -35,7 +35,7 @@ module ConsulCookbook
       attribute(:parameters, option_collector: true, default: {})
 
       def to_json
-        JSON.pretty_generate(type => parameters.merge(name: name), quicks_mode: true)
+        JSON.pretty_generate(type => parameters.merge(name: name))
       end
 
       action(:create) do

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -35,7 +35,7 @@ module ConsulCookbook
       attribute(:parameters, option_collector: true, default: {})
 
       def to_json
-        JSON.pretty_generate({ type: type }.merge(parameters), quicks_mode: true)
+        JSON.pretty_generate({ type: type }.merge(parameters))
       end
 
       action(:create) do

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -23,8 +23,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
           port: 6379,
           interval: '10s',
           name: 'redis'
-        },
-        quicks_mode: true
+        }
       ))
     end
   end
@@ -46,8 +45,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
           http: 'http://localhost:5000/health',
           ttl: '30s',
           name: 'web-api',
-        },
-        quicks_mode: true
+        }
       ))
     end
   end

--- a/test/spec/libraries/consul_watch_spec.rb
+++ b/test/spec/libraries/consul_watch_spec.rb
@@ -20,8 +20,7 @@ describe ConsulCookbook::Resource::ConsulWatch do
           type: 'key',
           key: 'foo/bar/baz',
           handler: '/bin/false'
-        },
-        quicks_mode: true
+        }
       ))
     end
   end


### PR DESCRIPTION
I'm assuming these were initially `quirks_mode` flags to `JSON.pretty_generate`, and that somewhere along the way they got typo'ed and the usage got changed to where they leaked into the output? When I used `consul_definition` to create a service, `quicks_mode` ended up in the config, which caused:

`==> Error decoding '/etc/consul/scpr_testing_web.json': Config has invalid keys: quicks_mode`

Removed arguments in JSON calls, and removed references in the specs.