### PR TITLE
Fix directory permissions on config_dir and data_dir

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -145,12 +145,12 @@ module ConsulCookbook
             recursive true
             owner new_resource.user
             group new_resource.group
-            mode '0744'
+            mode '0755'
           end
 
           directory new_resource.config_dir do
             recursive true
-            mode '0644'
+            mode '0755'
           end
         end
         super


### PR DESCRIPTION
With `/etc/consul` getting created `0640`, consul was failing to start with a permission denied error trying to lstat a service definition.

`Error reading '/etc/consul': lstat /etc/consul/scpr_testing_web.json: permission denied`

```
vagrant@server-ubuntu-1204:~$ ls -l /etc/ | grep consul
drw-r--r-- 2 root   root    4096 Aug  3 14:49 consul
```

That directory should potentially be owned by `service_user` rather than `root`, but that doesn't affect operation. 