### PR TITLE
allow to define multiple checks/services

### DIFF
--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -28,7 +28,7 @@ module ConsulCookbook
 
       # @!attribute type
       # @return [String]
-      attribute(:type, equal_to: %w{check service})
+      attribute(:type, equal_to: %w{check service checks services})
 
       # @!attribute parameters
       # @return [Hash]


### PR DESCRIPTION
Hi @johnbellone 

You can define multiple checks/services at once, this should fix it to get around this issue: https://github.com/johnbellone/consul-cookbook/issues/201#issuecomment-130681435