### PR TITLE
do not delete consul data dir

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -167,10 +167,6 @@ module ConsulCookbook
           directory new_resource.config_dir do
             action :delete
           end
-
-          directory new_resource.data_dir do
-            action :delete
-          end
         end
         super
       end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -163,10 +163,6 @@ module ConsulCookbook
           file new_resource.filename do
             action :delete
           end
-
-          directory new_resource.config_dir do
-            action :delete
-          end
         end
         super
       end


### PR DESCRIPTION
Hi @johnbellone,

Disabling Consul service deletes the data dir (which could contain a lot of other things).

I propose that we dont remove the data dir by default which is very opinionated.

Plus, it does not appear to be actually working (assuming a data dir on `/consul`):

```
==> zs2:     ================================================================================
==> zs2:     Error executing action `disable` on resource 'consul_service[consul]'
==> zs2:     ================================================================================
==> zs2:
==> zs2:     Errno::ENOTEMPTY
==> zs2:     ----------------
==> zs2:     directory[/consul] (/var/chef/cache/cookbooks/consul/libraries/consul_service.rb line 171) had an error: Errno::ENOTEMPTY: Directory not empty @ dir_s_rmdir - /consul
==> zs2:
==> zs2:     Cookbook Trace:
==> zs2:     ---------------
==> zs2:     /var/chef/cache/cookbooks/poise/files/halite_gem/poise/helpers/notifying_block.rb:69:in `notifying_block'
==> zs2:     /var/chef/cache/cookbooks/consul/libraries/consul_service.rb:162:in `action_disable'
==> zs2:
==> zs2:     Resource Declaration:
==> zs2:     ---------------------
==> zs2:     # In /var/chef/cache/cookbooks/gz-consul/recipes/default.rb
==> zs2:
==> zs2:      50: consul_service node['consul']['service_name'] do |r|
==> zs2:      51:   data_dir node['gz-consul']['config']['data_dir']
==> zs2:      52:   user node['consul']['service_user']
==> zs2:      53:   group node['consul']['service_group']
==> zs2:      54:   version node['consul']['version']
==> zs2:      55:   config_file node['gz-consul']['config_path']
==> zs2:      56:   node['consul']['service'].each_pair { |k, v| r.send(k, v) }
==> zs2:      57:   if node['gz-consul']['nuke']
==> zs2:      58:     action [:disable, :stop]
==> zs2:      59:   else
==> zs2:      60:     subscribes :restart, %|file[#{node['gz-consul']['config_path']}|, :delayed
==> zs2:      61:     action service_status
==> zs2:      62:   end
==> zs2:      63:   ignore_failure true if node['gz-consul']['nuke']
```

Thanks for considering it, deleting the data dir should be left to the user.