### PR TITLE
Add support for advertise_addr_wan

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -46,6 +46,7 @@ module ConsulCookbook
       attribute(:acl_ttl, kind_of: String)
       attribute(:addresses, kind_of: [Hash, Mash])
       attribute(:advertise_addr, kind_of: String)
+      attribute(:advertise_addr_wan, kind_of: String)
       attribute(:bind_addr, kind_of: String)
       attribute(:bootstrap, equal_to: [true, false], default: false)
       attribute(:bootstrap_expect, kind_of: Integer, default: 3)
@@ -87,7 +88,7 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recurser retry_interval server server_name skip_leave_on_interrupt start_join statsd_addr statsite_addr syslog_facility ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
+        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recurser retry_interval server server_name skip_leave_on_interrupt start_join statsd_addr statsite_addr syslog_facility ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
         for_keeps << %i{ca_file cert_file key_file} if tls?
         config = to_hash.keep_if do |k, _|
           for_keeps.include?(k.to_sym)


### PR DESCRIPTION
I discovered support for the advertise_addr_wan config option was missing so I wrote a quick patch to add it in.

https://www.consul.io/docs/agent/options.html#advertise_addr_wan