### PR TITLE
Add provider for consul acls

### DIFF
--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -1,0 +1,65 @@
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2014, 2015 Bloomberg Finance L.P.
+#
+require 'poise'
+
+module ConsulCookbook
+  module Resource
+    # @since 1.0.0
+    class ConsulACL < Chef::Resource
+      include Poise(fused: true)
+      provides(:consul_acl)
+      default_action(:create)
+
+      # @!attribute name
+      # @return [String]
+      attribute(:name, name_attribute: true, kind_of: String)
+      # @!attribute rules
+      # @return [String]
+      attribute(:rules, kind_of: String)
+      # @!attribute id
+      # @return [String]
+      attribute(:id, kind_of: String)
+      # @!attribute type
+      # @return [String]
+      attribute(:type, kind_of: String, default: 'client', required: true)
+
+      action :create do
+        ruby_block @new_resource.name do
+          data = {}
+          data['Name'] = new_resource.name
+          data['Type'] = new_resource.type
+          data['Rules'] = new_resource.rules
+          data['ID'] = new_resource.id unless new_resource.id.nil?
+          block { client.manage_acl(data) }
+          only_if { !current_resource || update_required? }
+        end
+      end
+
+      action :delete do
+        ruby_block new_resource.name do
+          block { client.delete_acl(new_resource.name) }
+          only_if { current_resource }
+        end
+      end
+
+      def client
+        @client ||= Chef::Consul::Client.new(nil, node['consul']['ports']['http'], node['consul']['acl_master_token'])
+      end
+
+      def load_current_resource
+        if @new_resource.id
+          @current_resource = client.get_acl_by_id(@new_resource.id)
+        else
+          @current_resource = client.get_acl_by_name(@new_resource.name)
+        end
+      end
+
+      def update_required?
+        current_resource['Rules'] != new_resource.rules || current_resource['Type'] != new_resource.type
+      end
+    end
+  end
+end

--- a/libraries/consul_client.rb
+++ b/libraries/consul_client.rb
@@ -1,0 +1,72 @@
+class Chef
+  module Consul
+    class Client
+      def initialize(host = '127.0.0.1', port = 8500, token = nil)
+        require 'net/http'
+        require 'json'
+        @host = host
+        @port = port
+        @base_uri = "http://#{@host}:#{@port}/v1"
+        @token = token || nil
+      end
+
+      def get_acl_by_name(resource)
+        acls = get('acl/list')
+        acls.find { |acl| acl['Name'] == resource }
+      end
+
+      def get_acl_by_id(resource)
+        acls = get("acl/info/#{resource}")
+        acls.find { |acl| acl['ID'] == resource }
+      end
+
+      def manage_acl(data)
+        if data['ID']
+          put("acl/update/#{data['ID']}", data)
+        else
+          put('acl/create', data)
+        end
+      end
+
+      def delete_acl(resource)
+        id = get_acl_by_name(resource)['ID']
+        put("acl/destroy/#{id}")
+      end
+
+      private
+
+      def http_request(method, uri, data = nil)
+        method = {
+          get: Net::HTTP::Get,
+          put: Net::HTTP::Put
+        }.fetch(method)
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        request = method.new(uri.request_uri)
+        request.body = data.to_json if data
+        response = http.request(request)
+
+        if response.code.to_i == 403
+          fail 'Authentication Error'
+        elsif response.code.to_i != 200
+          fail "Failed to process request #{uri} #{response.inspect}"
+        end
+        response
+      end
+
+      def get(request_uri)
+        url = "#{@base_uri}/#{request_uri}?token=#{@token}"
+        uri = URI.parse(url)
+        response = http_request(:get, uri)
+        JSON.parse("[#{response.body}]")[0]
+      end
+
+      def put(request_uri, data = nil)
+        url = "#{@base_uri}/#{request_uri}?token=#{@token}"
+        uri = URI.parse(url)
+        response = http_request(:put, uri, data)
+        JSON.parse("[#{response.body}]")[0]
+      end
+    end
+  end
+end

--- a/test/spec/libraries/consul_acl_spec.rb
+++ b/test/spec/libraries/consul_acl_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+require_relative '../../../libraries/consul_acl'
+
+describe ConsulCookbook::Resource::ConsulACL do
+  step_into(:consul_acl)
+  let(:chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
+
+  context 'acl definition' do
+    recipe do
+      consul_acl 'my-team-token' do
+        rules ({'service' => { 'our-team-services' => 'write' }}.to_json)
+      end
+    end
+
+    it { is_expected.to run_ruby_block('my-team-token') }
+  end
+end


### PR DESCRIPTION
This patch introduces acl provider for consul.
Most consul resources can injected as configuration file, acls however
have to interacted with through http api.
ConsulClient library exposes minimum helpers for such interaction.

This patch is based on the work of @InformatiQ