### PR TITLE
Fixing the syntax for Consul watches

### DIFF
--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -35,7 +35,7 @@ module ConsulCookbook
       attribute(:parameters, option_collector: true, default: {})
 
       def to_json
-        JSON.pretty_generate({ type: type }.merge(parameters))
+        JSON.pretty_generate(watches: [{ type: type }.merge(parameters)])
       end
 
       action(:create) do

--- a/test/spec/libraries/consul_watch_spec.rb
+++ b/test/spec/libraries/consul_watch_spec.rb
@@ -19,9 +19,13 @@ describe ConsulCookbook::Resource::ConsulWatch do
       .with(user: 'consul', group: 'consul', mode: '0640')
       .with(content: JSON.pretty_generate(
         {
-          type: 'key',
-          key: 'foo/bar/baz',
-          handler: '/bin/false'
+          watches: [
+            {
+              type: 'key',
+              key: 'foo/bar/baz',
+              handler: '/bin/false'
+            }
+          ]
         }
       ))
     end


### PR DESCRIPTION
The previous syntax resulted in Consul being unable to parse the generated config file.

Updated the relevant unit test