### PR TITLE
support to specify explicit service name other that filename

### DIFF
--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -35,7 +35,9 @@ module ConsulCookbook
       attribute(:parameters, option_collector: true, default: {})
 
       def to_json
-        JSON.pretty_generate(type => parameters.merge(name: name))
+        final_parameters = parameters
+        final_parameters = final_parameters.merge(name: name) if final_parameters[:name].nil?
+        JSON.pretty_generate(type => final_parameters)
       end
 
       action(:create) do

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -29,6 +29,30 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     end
   end
 
+  context 'service definition with explicit name' do
+    recipe do
+      consul_definition 'redis' do
+        type 'service'
+        parameters(name: 'myredis', tags: %w{master}, address: '127.0.0.1', port: 6379, interval: '10s')
+      end
+    end
+
+    it { is_expected.to create_directory('/etc/consul') }
+    it do
+      is_expected.to create_file('/etc/consul/redis.json')
+      .with(user: 'consul', group: 'consul', mode: '0640')
+      .with(content: JSON.pretty_generate(
+        service: {
+          name: 'myredis',
+          tags: ['master'],
+          address: '127.0.0.1',
+          port: 6379,
+          interval: '10s'
+        }
+      ))
+    end
+  end
+
   context 'check definition' do
     recipe do
       consul_definition 'web-api' do


### PR DESCRIPTION
Just a small fix so that name of service can be different that name of chef resource:
```ruby
consul_definition 'redis' do
        type 'service'
        parameters(
           name: 'myredis', # <<<--- this had no effect before
           tags: %w{master}, 
           address: '127.0.0.1', 
           port: 6379,
           interval: '10s')
end
```

All covered in tests. Without this change the case would fail