### PR TITLE
Install recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,11 @@ default['consul']['service']['config_dir'] = '/etc/consul'
 default['consul']['service']['binary_url'] = "https://dl.bintray.com/mitchellh/consul/%{filename}.zip" # rubocop:disable Style/StringLiterals
 default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'
 
+default['consul']['install']['install_method'] = 'binary'
+default['consul']['install']['config_dir'] = '/etc/consul'
+default['consul']['install']['binary_url'] = "https://dl.bintray.com/mitchellh/consul/%{filename}.zip" # rubocop:disable Style/StringLiterals
+default['consul']['install']['source_url'] = 'https://github.com/hashicorp/consul'
+
 default['consul']['version'] = '0.5.2'
 default['consul']['checksums'] = {
   '0.5.0_darwin_amd64' => '24d9758c873e9124e0ce266f118078f87ba8d8363ab16c2e59a3cd197b77e964',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,11 +26,6 @@ default['consul']['config']['ports'] = {
   'server'   => 8300
 }
 
-default['consul']['service']['install_method'] = 'binary'
-default['consul']['service']['config_dir'] = '/etc/consul'
-default['consul']['service']['binary_url'] = "https://dl.bintray.com/mitchellh/consul/%{filename}.zip" # rubocop:disable Style/StringLiterals
-default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'
-
 default['consul']['install']['install_method'] = 'binary'
 default['consul']['install']['config_dir'] = '/etc/consul'
 default['consul']['install']['binary_url'] = "https://dl.bintray.com/mitchellh/consul/%{filename}.zip" # rubocop:disable Style/StringLiterals

--- a/libraries/consul_install.rb
+++ b/libraries/consul_install.rb
@@ -1,0 +1,103 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2014, 2015 Bloomberg Finance L.P.
+#
+require 'poise_service/service_mixin'
+
+module ConsulCookbook
+  module Resource
+    # Resource for managing the Consul service on an instance.
+    # @since 1.0.0
+    class ConsulInstall < Chef::Resource
+      include Poise
+      provides(:consul_install)
+      actions(:install, :uninstall)
+
+      # @!attribute version
+      # @return [String]
+      attribute(:version, kind_of: String, required: true)
+
+      # @!attribute install_path
+      # @return [String]
+      attribute(:install_path, kind_of: String, default: '/srv')
+
+      # @!attribute user
+      # @return [String]
+      attribute(:user, kind_of: String, default: 'consul')
+
+      # @!attribute group
+      # @return [String]
+      attribute(:group, kind_of: String, default: 'consul')
+
+      # @!attribute binary_url
+      # @return [String]
+      attribute(:binary_url, kind_of: String)
+
+      # @!attribute data_dir
+      # @return [String]
+      attribute(:data_dir, kind_of: String, default: '/var/lib/consul')
+
+      # @!attribute config_dir
+      # @return [String]
+      attribute(:config_dir, kind_of: String, default: '/etc/consul')
+
+      def binary_checksum
+        node['consul']['checksums'].fetch(binary_filename)
+      end
+
+      def binary_filename
+        arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
+        [version, node['os'], arch].join('_')
+      end
+    end
+  end
+
+  module Provider
+    # Provider for managing the Consul service on an instance.
+    # @since 1.0.0
+    class ConsulInstall < Chef::Provider
+      include Poise
+      provides(:consul_install)
+
+      def action_install
+        notifying_block do
+            artifact = libartifact_file "consul-#{new_resource.version}" do
+              artifact_name 'consul'
+              artifact_version new_resource.version
+              install_path new_resource.install_path
+              remote_url new_resource.binary_url % { filename: new_resource.binary_filename }
+              remote_checksum new_resource.binary_checksum
+            end
+
+            link '/usr/local/bin/consul' do
+              to ::File.join(artifact.current_path, 'consul')
+            end
+
+          [new_resource.data_dir, new_resource.config_dir].each do |dirname|
+            directory dirname do
+              recursive true
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
+          end
+        end
+      end
+
+      def action_uninstall
+        notifying_block do
+          link '/usr/local/bin/consul' do
+            action :delete
+          end
+
+          directory "#{new_resource.install_path}/consul" do
+            recursive true
+            action :delete
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -15,18 +15,6 @@ module ConsulCookbook
       provides(:consul_service)
       include PoiseService::ServiceMixin
 
-      # @!attribute version
-      # @return [String]
-      attribute(:version, kind_of: String, required: true)
-
-      # @!attribute install_method
-      # @return [Symbol]
-      attribute(:install_method, default: 'binary', equal_to: %w{source binary package})
-
-      # @!attribute install_path
-      # @return [String]
-      attribute(:install_path, kind_of: String, default: '/srv')
-
       # @!attribute config_file
       # @return [String]
       attribute(:config_file, kind_of: String, default: '/etc/consul.json')
@@ -42,18 +30,6 @@ module ConsulCookbook
       # @!attribute environment
       # @return [String]
       attribute(:environment, kind_of: Hash, default: lazy { default_environment })
-
-      # @!attribute package_name
-      # @return [String]
-      attribute(:package_name, kind_of: String, default: 'consul')
-
-      # @!attribute binary_url
-      # @return [String]
-      attribute(:binary_url, kind_of: String)
-
-      # @!attribute source_url
-      # @return [String]
-      attribute(:source_url, kind_of: String)
 
       # @!attribute data_dir
       # @return [String]
@@ -73,15 +49,6 @@ module ConsulCookbook
       def command
         "/usr/bin/env consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end
-
-      def binary_checksum
-        node['consul']['checksums'].fetch(binary_filename)
-      end
-
-      def binary_filename
-        arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
-        [version, node['os'], arch].join('_')
-      end
     end
   end
 
@@ -92,79 +59,6 @@ module ConsulCookbook
       include Poise
       provides(:consul_service)
       include PoiseService::ServiceMixin
-
-      def action_enable
-        notifying_block do
-          package new_resource.package_name do
-            version new_resource.version unless new_resource.version.nil?
-            only_if { new_resource.install_method == 'package' }
-          end
-
-          if node['platform'] == 'windows'
-            include_recipe 'chocolatey::default'
-
-            chocolatey new_resource.package_name do
-              version new_resource.version
-            end
-          end
-
-          if new_resource.install_method == 'binary'
-            artifact = libartifact_file "consul-#{new_resource.version}" do
-              artifact_name 'consul'
-              artifact_version new_resource.version
-              install_path new_resource.install_path
-              remote_url new_resource.binary_url % { filename: new_resource.binary_filename }
-              remote_checksum new_resource.binary_checksum
-            end
-
-            link '/usr/local/bin/consul' do
-              to ::File.join(artifact.current_path, 'consul')
-            end
-          end
-
-          if new_resource.install_method == 'source'
-            include_recipe 'golang::default'
-
-            source_dir = directory ::File.join(new_resource.install_path, 'consul', 'src') do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-
-            git ::File.join(source_dir.path, "consul-#{new_resource.version}") do
-              repository new_resource.source_url
-              reference new_resource.version
-              action :checkout
-            end
-
-            golang_package 'github.com/hashicorp/consul' do
-              action :install
-            end
-
-            directory ::File.join(new_resource.install_path, 'bin') do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-
-            link ::File.join(new_resource.install_path, 'bin', 'consul') do
-              to ::File.join(source_dir.path, "consul-#{new_resource.version}", 'consul')
-            end
-          end
-
-          [new_resource.data_dir, new_resource.config_dir].each do |dirname|
-            directory dirname do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-          end
-        end
-        super
-      end
 
       def action_disable
         notifying_block do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,5 +42,11 @@ consul_service node['consul']['service_name'] do |r|
   config_file config.path
 
   node['consul']['service'].each_pair { |k, v| r.send(k, v) }
-  subscribes :restart, "consul_config[#{config.name}]", :delayed
+  subscribes :restart, "consul_config[#{config.name}]", :delayed if node['consul']['install_only']
+end
+
+if node['consul']['install_only']
+  consul_service node['consul']['service_name'] do
+    action :disable
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ consul_service node['consul']['service_name'] do |r|
   config_file config.path
 
   node['consul']['service'].each_pair { |k, v| r.send(k, v) }
-  subscribes :restart, "consul_config[#{config.name}]", :delayed if node['consul']['install_only']
+  subscribes :restart, "consul_config[#{config.name}]", :delayed unless node['consul']['install_only']
 end
 
 if node['consul']['install_only']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,11 +42,5 @@ consul_service node['consul']['service_name'] do |r|
   config_file config.path
 
   node['consul']['service'].each_pair { |k, v| r.send(k, v) }
-  subscribes :restart, "consul_config[#{config.name}]", :delayed unless node['consul']['install_only']
-end
-
-if node['consul']['install_only']
-  consul_service node['consul']['service_name'] do
-    action :disable
-  end
+  subscribes :restart, "consul_config[#{config.name}]", :delayed
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,12 +35,20 @@ config = consul_config node['consul']['service_name'] do |r|
   node['consul']['config'].each_pair { |k, v| r.send(k, v) }
 end
 
-consul_service node['consul']['service_name'] do |r|
+install = consul_install node['consul']['install']['install_method'] do |r|
   user node['consul']['service_user']
   group node['consul']['service_group']
   version node['consul']['version']
+
+  node['consul']['install'].each_pair { |k, v| r.send(k, v) }
+end
+
+consul_service node['consul']['service_name'] do |r|
+  user node['consul']['service_user']
+  group node['consul']['service_group']
+  config_dir install.config_dir
   config_file config.path
 
-  node['consul']['service'].each_pair { |k, v| r.send(k, v) }
+  node['consul'].fetch('service', {}).each_pair { |k, v| r.send(k, v) }
   subscribes :restart, "consul_config[#{config.name}]", :delayed
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,0 +1,11 @@
+poise_service_user node['consul']['service_user'] do
+  group node['consul']['service_group']
+end
+
+consul_service node['consul']['service_name'] do |r|
+  user node['consul']['service_user']
+  group node['consul']['service_group']
+  version node['consul']['version']
+
+  node['consul']['install'].each_pair { |k, v| r.send(k, v) }
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -2,7 +2,7 @@ poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
 end
 
-consul_service node['consul']['service_name'] do |r|
+consul_install node['consul']['service_name'] do |r|
   user node['consul']['service_user']
   group node['consul']['service_group']
   version node['consul']['version']

--- a/test/cookbooks/consul_spec/recipes/consul_install.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_install.rb
@@ -1,0 +1,5 @@
+consul_install node[:install_method] do
+  version '0.5.2'
+  binary_url "https://dl.bintray.com/mitchellh/consul/%{filename}.zip"
+  action node[:consul_install_action] || :install
+end

--- a/test/cookbooks/consul_spec/recipes/consul_install.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_install.rb
@@ -1,5 +1,6 @@
 consul_install node[:install_method] do
   version '0.5.2'
   binary_url "https://dl.bintray.com/mitchellh/consul/%{filename}.zip"
+  source_url node[:consul_source] || ''
   action node[:consul_install_action] || :install
 end

--- a/test/spec/libraries/consul_install_spec.rb
+++ b/test/spec/libraries/consul_install_spec.rb
@@ -69,6 +69,14 @@ describe ConsulCookbook::Resource::ConsulInstall do
     it { is_expected.to_not create_directory('/srv/bin') }
     it { is_expected.to_not install_golang_package('github.com/hashicorp/consul') }
     it { is_expected.to_not create_link('/srv/bin/consul') }
+
+    context "on windows" do
+      let(:platform_chefspec_options) { {platform: 'windows', version: '2012r2'} }
+      recipe 'consul_spec::consul_install'
+
+      it { is_expected.to install_chocolatey('consul').with(version: '0.5.2') }
+      it { is_expected.to_not install_package('consul') }
+    end
   end
 
   context "for a package uninstall" do
@@ -80,6 +88,14 @@ describe ConsulCookbook::Resource::ConsulInstall do
     # Don't uninstall via other methods
     it { is_expected.to_not delete_directory('/srv/consul') }
     it { is_expected.to_not delete_link('/usr/local/bin/consul') }
+
+    context "on windows" do
+      let(:platform_chefspec_options) { {platform: 'windows', version: '2012r2'} }
+      recipe 'consul_spec::consul_install'
+
+      it { is_expected.to remove_chocolatey('consul') }
+      it { is_expected.to_not remove_package('consul') }
+    end
   end
 
   context "for a source install" do

--- a/test/spec/libraries/consul_install_spec.rb
+++ b/test/spec/libraries/consul_install_spec.rb
@@ -68,14 +68,6 @@ describe ConsulCookbook::Resource::ConsulInstall do
     it { is_expected.to_not create_directory('/srv/bin') }
     it { is_expected.to_not install_golang_package('github.com/hashicorp/consul') }
     it { is_expected.to_not create_link('/srv/bin/consul') }
-
-    context "on windows" do
-      let(:platform_chefspec_options) { {platform: 'windows', version: '2012r2'} }
-      recipe 'consul_spec::consul_install'
-
-      it { is_expected.to install_chocolatey('consul').with(version: '0.5.2') }
-      it { is_expected.to_not install_package('consul') }
-    end
   end
 
   context "for a package uninstall" do
@@ -87,14 +79,6 @@ describe ConsulCookbook::Resource::ConsulInstall do
     # Don't uninstall via other methods
     it { is_expected.to_not delete_directory('/srv/consul') }
     it { is_expected.to_not delete_link('/usr/local/bin/consul') }
-
-    context "on windows" do
-      let(:platform_chefspec_options) { {platform: 'windows', version: '2012r2'} }
-      recipe 'consul_spec::consul_install'
-
-      it { is_expected.to remove_chocolatey('consul') }
-      it { is_expected.to_not remove_package('consul') }
-    end
   end
 
   context "for a source install" do

--- a/test/spec/libraries/consul_install_spec.rb
+++ b/test/spec/libraries/consul_install_spec.rb
@@ -3,7 +3,6 @@ require_relative '../../../libraries/consul_install'
 
 describe ConsulCookbook::Resource::ConsulInstall do
   step_into(:consul_install)
-  let(:provider) { ConsulCookbook::Provider::ConsulInstall }
   let(:node_attributes) { Hash.new }
   let(:platform_chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
   let(:chefspec_options) { node_attributes.merge platform_chefspec_options }

--- a/test/spec/libraries/consul_install_spec.rb
+++ b/test/spec/libraries/consul_install_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require_relative '../../../libraries/consul_install'
+
+describe ConsulCookbook::Resource::ConsulInstall do
+  step_into(:consul_install)
+  let(:node_attributes) { Hash.new }
+  let(:default_chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
+  let(:chefspec_options) { node_attributes.merge default_chefspec_options }
+
+  context 'for a binary install' do
+    let(:node_attributes) { { normal_attributes: { install_method: 'binary' } } }
+    recipe 'consul_spec::consul_install'
+
+    it { is_expected.to create_directory('/etc/consul') }
+    it { is_expected.to create_directory('/var/lib/consul') }
+
+    it do is_expected.to create_libartifact_file('consul-0.5.2')
+      .with(artifact_name: 'consul',
+            artifact_version: '0.5.2',
+            install_path: '/srv',
+            remote_url: "https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip",
+            remote_checksum: '171cf4074bfca3b1e46112105738985783f19c47f4408377241b868affa9d445')
+    end
+
+    it { is_expected.to create_link('/usr/local/bin/consul').with(to: '/srv/consul/current/consul') }
+  end
+
+  context 'for a binary delete' do
+    let(:node_attributes) { { normal_attributes: {install_method: 'binary', consul_install_action: :uninstall} } }
+    recipe 'consul_spec::consul_install'
+
+    it { is_expected.to delete_directory('/srv/consul') }
+    it { is_expected.to delete_link('/usr/local/bin/consul') }
+  end
+end

--- a/test/spec/libraries/consul_install_spec.rb
+++ b/test/spec/libraries/consul_install_spec.rb
@@ -23,6 +23,9 @@ describe ConsulCookbook::Resource::ConsulInstall do
     end
 
     it { is_expected.to create_link('/usr/local/bin/consul').with(to: '/srv/consul/current/consul') }
+
+    # Don't install via other methods
+    it { is_expected.to_not install_package('consul') }
   end
 
   context 'for a binary delete' do
@@ -31,5 +34,33 @@ describe ConsulCookbook::Resource::ConsulInstall do
 
     it { is_expected.to delete_directory('/srv/consul') }
     it { is_expected.to delete_link('/usr/local/bin/consul') }
+
+    # Don't uninstall via other methods
+    it { is_expected.to_not remove_package('consul') }
+  end
+
+  context 'for a package install' do
+    let(:node_attributes) { { normal_attributes: { install_method: 'package' } } }
+    recipe 'consul_spec::consul_install'
+
+    it { is_expected.to create_directory('/etc/consul') }
+    it { is_expected.to create_directory('/var/lib/consul') }
+
+    it { is_expected.to install_package('consul').with(version: '0.5.2') }
+
+    # Don't install via other methods
+    it { is_expected.to_not create_libartifact_file('consul-0.5.2') }
+    it { is_expected.to_not create_link('/usr/local/bin/consul') }
+  end
+
+  context "for a package uninstall" do
+    let(:node_attributes) { { normal_attributes: {install_method: 'package', consul_install_action: :uninstall} } }
+    recipe 'consul_spec::consul_install'
+
+    it { is_expected.to remove_package('consul') }
+
+    # Don't uninstall via other methods
+    it { is_expected.to_not delete_directory('/srv/consul') }
+    it { is_expected.to_not delete_link('/usr/local/bin/consul') }
   end
 end

--- a/test/spec/libraries/consul_service_spec.rb
+++ b/test/spec/libraries/consul_service_spec.rb
@@ -8,7 +8,12 @@ describe ConsulCookbook::Resource::ConsulService do
   context 'with default properties' do
     recipe 'consul::default'
 
-    it { expect(chef_run).to create_directory('/etc/consul') }
-    it { is_expected.to create_directory('/var/lib/consul') }
+    it {
+      is_expected.to enable_consul_service('consul')
+      .with(user:  'consul')
+      .with(group: 'consul')
+      .with(config_dir: '/etc/consul')
+      .with(config_file: '/etc/consul.json')
+    }
   end
 end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'poise_boiler/spec_helper'
+require_relative 'support/matchers'

--- a/test/spec/support/matchers.rb
+++ b/test/spec/support/matchers.rb
@@ -1,0 +1,9 @@
+# Temp solution until some ChefSpec matchers are included in chocolatey
+
+def install_chocolatey(resource_name)
+  ChefSpec::Matchers::ResourceMatcher.new(:chocolatey, :install, resource_name)
+end
+
+def remove_chocolatey(resource_name)
+  ChefSpec::Matchers::ResourceMatcher.new(:chocolatey, :remove, resource_name)
+end


### PR DESCRIPTION
Description
---------------
For use cases like `packer` or other OS artifact builders, it is helpful to be able to only install the software that is need without configuring it to run as a service on initial boot.  For example, you can install consul on a instance and put in place a few standard checks that would be on all machines (Memory, CPU, Disk Utilization) and pack that into your build and it is preinstalled when you boot up your box and the provisioning step only needs configure any additional customizations.

I was originally going to create a `consul::install` recipe, but based on how baked in the installation code is in the service provider, it was not really possible.  This ends up making this a bit of a hack because the recipe ends up adding a service only to delete it, but based on what I can tell, deleting it will only remove the base config file and the service definition, but leave the binary in place.


My original workaround without this change was going to be the following:

```
include_recipe 'consul'

consul_service node['consul']['service_name'] do
  action :disable
end
```

But the delayed `subscribes :restart` that is baked into the `consul::default` recipe will actually fail because the service definition file on the machine will no longer exist.
