### PR TITLE
Updates binary package URL to new hashicorp directory/filename structure

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,8 @@ default['consul']['config']['ports'] = {
 
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['config_dir'] = '/etc/consul'
-default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
+default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/consul_%{filename}.zip" # rubocop:disable Style/StringLiterals
+
 default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'
 
 default['consul']['version'] = '0.6.0'


### PR DESCRIPTION
Looks like hashicorp changed their URL structure. This changes the default URL in order to get downloads working again.