### PR TITLE
Guard against owning /etc

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -149,6 +149,7 @@ module ConsulCookbook
             owner new_resource.owner
             group new_resource.group
             mode '0755'
+            not_if { ::File.dirname(new_resource.path) == '/etc' }
           end
 
           file new_resource.path do


### PR DESCRIPTION
The `consul_config` resource ensures the directory exists for the config file and is owned by the service user.  Unfortunately since the default path for the config file is `/etc/config.json`, this cookbook is changing ownership of `/etc` to the Consul user, which is causing problems on some of my nodes.

This PR simply guards the directory resource from managing the directory if it is `/etc`. This may not be the best approach, but it was the simplest way to solve the problem.  Please let me know if there's a better way and I'll submit another PR. Thanks!