### PR TITLE
Add ACL support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,3 +46,17 @@ suites:
     excludes:
       - centos-7.1
       - centos-6.6
+  - name: acl
+    run_list:
+      - recipe[consul::default]
+      - recipe[consul::client_gem]
+      - recipe[consul_spec::acl]
+    attributes:
+      consul:
+        config:
+          bootstrap: true
+          server: true
+          datacenter: fortmeade
+          acl_master_token: doublesecret
+          acl_datacenter: fortmeade
+          acl_default_policy: deny

--- a/Berksfile
+++ b/Berksfile
@@ -8,4 +8,5 @@ end
 
 group :integration do
   cookbook 'consul_spec', path: 'test/cookbooks/consul_spec'
+  cookbook 'apt'
 end

--- a/README.md
+++ b/README.md
@@ -126,6 +126,39 @@ times we need to tell Consul to actually reload configurations. If
 there are several definitions this may save a little time off your
 Chef run.
 
+### ACLs
+The `consul_acl` resource allows management of [Consul ACL rules][15]. Supported
+actions are `:create` and `:delete`. The `:create` action will update/insert
+as necessary.
+
+The `consul_acl` resource requires the [Diplomat Ruby API][16] gem to be
+installed and available to Chef before using the resource. This can be
+accomplished by including `consul::client_gem` recipe in your run list.
+
+In order to make the resource idempotent and only notify when necessary, the
+`id` field is always required (defaults to the name of the resource).
+If `type` is not provided, it will default to "client". The `acl_name`
+and `rules` attributes are also optional; if not included they will be empty
+in the resulting ACL.
+
+The example below will create a client ACL token with an `ID` of the given UUID,
+`Name` of "AwesomeApp Token", and `Rules` of the given string.
+```ruby
+consul_acl '49f06aa9-782f-465a-becf-44f0aaefd335' do
+  acl_name 'AwesomeApp Token'
+  type 'client'
+  rules <<-EOS.gsub(/^\s{4}/, '')
+    key "" {
+      policy = "read"
+    }
+    service "" {
+      policy = "write"
+    }
+  EOS
+  auth_token node['consul']['config']['acl_master_token']
+end
+```
+
 ### Execute
 The command-line agent provides a mechanism to facilitate remote
 execution. For example, this can be used to run the `uptime` command
@@ -143,7 +176,7 @@ nature of this command it is _impossible_ for it to be idempotent.
 
 ### UI
 
-`consul_ui` resource can be used to download and extract the 
+`consul_ui` resource can be used to download and extract the
 [consul web UI](https://www.consul.io/intro/getting-started/ui.html).
 It can be done with a block like this:
 
@@ -158,7 +191,7 @@ end
 Assuming consul version `0.5.2` above block would create `/srv/consul-ui/0.5.2`
 and symlink `/srv/consul-ui/current`.
 
-It does not change agent's configuration by itself. 
+It does not change agent's configuration by itself.
 `consul_config` resource should be modified explicitly in order to host the web page.
 
 ```ruby
@@ -186,3 +219,5 @@ This is optional, because consul UI can be hosted by any web server.
 [12]: https://consul.io/docs/commands/exec.html
 [13]:https://en.wikipedia.org/wiki/Quorum_(distributed_computing)
 [14]: https://github.com/johnbellone/consul-cluster-cookbook
+[15]: https://www.consul.io/docs/internals/acl.html
+[16]: https://github.com/WeAreFarmGeek/diplomat

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,8 @@ default['consul']['config']['ports'] = {
   'server'   => 8300
 }
 
+default['consul']['diplomat_version'] = nil
+
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['config_dir'] = '/etc/consul'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals

--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -8,10 +8,11 @@ require 'poise'
 
 module ConsulCookbook
   module Resource
-    # @since 1.0.0
+    # Resource for managing  Consul ACLs.
     class ConsulAcl < Chef::Resource
-      include Poise(fused: true)
+      include Poise
       provides(:consul_acl)
+      actions(:create, :delete)
       default_action(:create)
 
       # @!attribute url
@@ -38,6 +39,36 @@ module ConsulCookbook
       # @return [String]
       attribute(:rules, kind_of: String, default: '')
 
+      def to_acl
+        { 'ID' => id, 'Type' => type, 'Name' => acl_name, 'Rules' => rules }
+      end
+    end
+  end
+
+  module Provider
+    # Provider for managing  Consul ACLs.
+    class ConsulAcl < Chef::Provider
+      include Poise
+      provides(:consul_acl)
+
+      def action_create
+        configure_diplomat
+        unless up_to_date?
+          Diplomat::Acl.create(new_resource.to_acl)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
+      def action_delete
+        configure_diplomat
+        unless Diplomat::Acl.info(new_resource.id).empty?
+          Diplomat::Acl.destroy(new_resource.id)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
+      protected
+
       def configure_diplomat
         begin
           require 'diplomat'
@@ -46,42 +77,17 @@ module ConsulCookbook
                               'include recipe[consul::client_gem] to install.'
         end
         Diplomat.configure do |config|
-          config.url = url
-          config.acl_token = auth_token
+          config.url = new_resource.url
+          config.acl_token = new_resource.auth_token
           config.options = { request: { timeout: 10 } }
         end
       end
 
-      def acl_definition
-        acl = {}
-        acl['ID'] = id
-        acl['Type'] = type
-        acl['Name'] = acl_name
-        acl['Rules'] = rules
-        acl
-      end
-
       def up_to_date?
-        old_acl = Diplomat::Acl.info(acl_definition['ID']).first
+        old_acl = Diplomat::Acl.info(new_resource.to_acl['ID']).first
         return false if old_acl.nil?
         old_acl.select! { |k, _v| %w(ID Type Name Rules).include?(k) }
-        old_acl == acl_definition
-      end
-
-      action(:create) do
-        new_resource.configure_diplomat
-        unless new_resource.up_to_date?
-          Diplomat::Acl.create(new_resource.acl_definition)
-          new_resource.updated_by_last_action(true)
-        end
-      end
-
-      action(:delete) do
-        new_resource.configure_diplomat
-        unless Diplomat::Acl.info(new_resource.id).empty?
-          Diplomat::Acl.destroy(new_resource.id)
-          new_resource.updated_by_last_action(true)
-        end
+        old_acl == new_resource.to_acl
       end
     end
   end

--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -1,0 +1,88 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2014, 2015 Bloomberg Finance L.P.
+#
+require 'poise'
+
+module ConsulCookbook
+  module Resource
+    # @since 1.0.0
+    class ConsulAcl < Chef::Resource
+      include Poise(fused: true)
+      provides(:consul_acl)
+      default_action(:create)
+
+      # @!attribute url
+      # @return [String]
+      attribute(:url, kind_of: String, default: 'http://localhost:8500')
+
+      # @!attribute auth_token
+      # @return [String]
+      attribute(:auth_token, kind_of: String, required: true)
+
+      # @!attribute id
+      # @return [String]
+      attribute(:id, kind_of: String, name_attribute: true)
+
+      # @!attribute acl_name
+      # @return [String]
+      attribute(:acl_name, kind_of: String, default: '')
+
+      # @!attribute type
+      # @return [String]
+      attribute(:type, equal_to: %w{client management}, default: 'client')
+
+      # @!attribute rules
+      # @return [String]
+      attribute(:rules, kind_of: String, default: '')
+
+      def configure_diplomat
+        begin
+          require 'diplomat'
+        rescue LoadError
+          fail 'The diplomat gem is required for the consul_acl resource; ' \
+               'include recipe[consul::client_gem] to install.'
+        end
+        Diplomat.configure do |config|
+          config.url = url
+          config.acl_token = auth_token
+          config.options = { request: {timeout: 10 } }
+        end
+      end
+
+      def acl_definition
+        acl = {}
+        acl['ID'] = id
+        acl['Type'] = type
+        acl['Name'] = acl_name
+        acl['Rules'] = rules
+        acl
+      end
+
+      def up_to_date?
+        old_acl = Diplomat::Acl.info(acl_definition['ID']).first
+        return false if old_acl.nil?
+        old_acl.select! { |k, _v| %w(ID Type Name Rules).include?(k) }
+        old_acl == acl_definition
+      end
+
+      action(:create) do
+        new_resource.configure_diplomat
+        unless new_resource.up_to_date?
+          Diplomat::Acl.create(new_resource.acl_definition)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+
+      action(:delete) do
+        new_resource.configure_diplomat
+        unless Diplomat::Acl.info(new_resource.id).empty?
+          Diplomat::Acl.destroy(new_resource.id)
+          new_resource.updated_by_last_action(true)
+        end
+      end
+    end
+  end
+end

--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -42,13 +42,13 @@ module ConsulCookbook
         begin
           require 'diplomat'
         rescue LoadError
-          fail 'The diplomat gem is required for the consul_acl resource; ' \
-               'include recipe[consul::client_gem] to install.'
+          raise RunTimeError, 'The diplomat gem is required; ' \
+                              'include recipe[consul::client_gem] to install.'
         end
         Diplomat.configure do |config|
           config.url = url
           config.acl_token = auth_token
-          config.options = { request: {timeout: 10 } }
+          config.options = { request: { timeout: 10 } }
         end
       end
 

--- a/recipes/client_gem.rb
+++ b/recipes/client_gem.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright 2014, 2015 Bloomberg Finance L.P.
+#
+
+chef_gem 'diplomat' do
+  version node['consul']['diplomat_version'] if node['consul']['diplomat_version']
+  action :install
+end

--- a/test/cookbooks/consul_spec/recipes/acl.rb
+++ b/test/cookbooks/consul_spec/recipes/acl.rb
@@ -1,0 +1,46 @@
+package 'curl'
+
+consul_acl 'anonymous' do
+  acl_name 'Anonymous Token'
+  type 'client'
+  url "http://localhost:#{node['consul']['config']['ports']['http']}"
+  auth_token node['consul']['config']['acl_master_token']
+  notifies :create, 'file[/tmp/anonymous-notified]', :immediately
+end
+
+file '/tmp/anonymous-notified' do
+  action :nothing
+end
+
+consul_acl 'management_token' do
+  acl_name 'Management Token'
+  type 'management'
+  auth_token node['consul']['config']['acl_master_token']
+  notifies :create, 'file[/tmp/management_token-notified]', :immediately
+end
+
+file '/tmp/management_token-notified' do
+  action :nothing
+end
+
+consul_acl 'delete_management_token' do
+  id 'management_token'
+  auth_token node['consul']['config']['acl_master_token']
+  action :delete
+end
+
+consul_acl 'non_existing_token' do
+  auth_token node['consul']['config']['acl_master_token']
+  action :delete
+end
+
+consul_acl 'reader_token' do
+  type 'client'
+  rules <<-EOS.gsub(/^\s{4}/, '')
+    dummyrule_line1
+    dummyrule_line2
+  EOS
+  auth_token node['consul']['config']['acl_master_token']
+end
+
+

--- a/test/integration/acl/serverspec/localhost/default_spec.rb
+++ b/test/integration/acl/serverspec/localhost/default_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe command('curl -s "http://localhost:8500/v1/acl/info/anonymous"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('"ID":"anonymous"') }
+  its(:stdout) { should match('"Name":"Anonymous Token"') }
+  its(:stdout) { should match('"Type":"client"') }
+  its(:stdout) { should match('"Rules":""') }
+end
+
+describe file('/tmp/anonymous-notified') do
+  it { should_not exist }
+end
+
+describe command('curl -s "http://localhost:8500/v1/acl/info/management_token"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('[]') }
+end
+
+describe file('/tmp/management_token-notified') do
+  it { should exist }
+end
+
+describe command('curl -s "http://localhost:8500/v1/acl/info/reader_token"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('"ID":"reader_token"') }
+  its(:stdout) { should match('"Name":""') }
+  its(:stdout) { should match('"Type":"client"') }
+  its(:stdout) { should match /\"Rules\":\"dummyrule_line1\\ndummyrule_line2\\n\"/ }
+end


### PR DESCRIPTION
This is a rough draft of a resource to provide ACL support using the `diplomat` gem as an API client.  It's not ready to merge yet since there's no unit tests, etc... however I wanted to throw it out there for comments and suggestions.

Since most of the work is being handled by diplomat there's really not much to it. It's passing the included integration tests, is idempotent, notifies correctly, etc.

A few noteworthy points:
* Since it requires a chef_gem there needs to be a way to install it. Rather than doing anything fancy in the resource I decided to leave it up to the user to ensure the gem is installed first.  A `consul::client_gem` recipe is included with the cookbook to do the needful.
* The diplomat version is not pinned, but an attribute exists to set the version if desired.
* I'm requiring diplomat in each of the action blocks rather than the top of the resource to prevent the gem from needing to be installed at compile-time (is this best-practice?).
* There is no `:update`... just `:create` and `:delete`. After tinkering with the Consul API for awhile it looks like the only difference between create and update in Consul's API is the fact that create can be called without an ID (it'll create the ACL with a random UUID if ID is not provided). So, to keep things simple/predictable the create endpoint is used for create/update and an ID is required.

Comments?  Thanks!