### PR TITLE
Added Windows Support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,5 @@ Style/GuardClause:
   Enabled: false
 Style/PercentLiteralDelimiters:
   Enabled: false
+Style/ModuleFunction:
+  Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,18 +4,23 @@
 #
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
+::Chef::Node.send(:include, ConsulCookbook::Helpers)
+
+# Only used on Linux
 default['consul']['service_name'] = 'consul'
 default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 
-default['consul']['config']['path'] = '/etc/consul.json'
 default['consul']['config']['bag_name'] = 'secrets'
 default['consul']['config']['bag_item'] = 'consul'
-default['consul']['config']['data_dir'] = '/var/lib/consul'
-default['consul']['config']['ca_file'] = '/etc/consul/ssl/CA/ca.crt'
-default['consul']['config']['cert_file'] = '/etc/consul/ssl/certs/consul.crt'
+
+default['consul']['config']['path'] = join_path prefix_path, 'consul.json'
+default['consul']['config']['data_dir'] = join_path prefix_path, 'data'
+default['consul']['config']['ca_file'] = join_path prefix_path, 'ssl', 'CA', 'ca.crt'
+default['consul']['config']['cert_file'] = join_path prefix_path, 'ssl', 'certs', 'consul.crt'
+default['consul']['config']['key_file'] = join_path prefix_path, 'ssl', 'private', 'consul.key'
+
 default['consul']['config']['client_addr'] = '0.0.0.0'
-default['consul']['config']['key_file'] = '/etc/consul/ssl/private/consul.key'
 default['consul']['config']['ports'] = {
   'dns'      => 8600,
   'http'     => 8500,
@@ -27,8 +32,10 @@ default['consul']['config']['ports'] = {
 
 default['consul']['diplomat_version'] = nil
 
+default['consul']['service']['config_dir'] = join_path prefix_path, 'conf.d'
+default['consul']['service']['data_dir'] = join_path prefix_path, 'data'
+
 default['consul']['service']['install_method'] = 'binary'
-default['consul']['service']['config_dir'] = '/etc/consul'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
 
 default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,11 +14,11 @@ default['consul']['service_group'] = 'consul'
 default['consul']['config']['bag_name'] = 'secrets'
 default['consul']['config']['bag_item'] = 'consul'
 
-default['consul']['config']['path'] = join_path prefix_path, 'consul.json'
-default['consul']['config']['data_dir'] = join_path prefix_path, 'data'
-default['consul']['config']['ca_file'] = join_path prefix_path, 'ssl', 'CA', 'ca.crt'
-default['consul']['config']['cert_file'] = join_path prefix_path, 'ssl', 'certs', 'consul.crt'
-default['consul']['config']['key_file'] = join_path prefix_path, 'ssl', 'private', 'consul.key'
+default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
+default['consul']['config']['data_dir'] = join_path data_prefix_path, 'data'
+default['consul']['config']['ca_file'] = join_path config_prefix_path, 'ssl', 'CA', 'ca.crt'
+default['consul']['config']['cert_file'] = join_path config_prefix_path, 'ssl', 'certs', 'consul.crt'
+default['consul']['config']['key_file'] = join_path config_prefix_path, 'ssl', 'private', 'consul.key'
 
 default['consul']['config']['client_addr'] = '0.0.0.0'
 default['consul']['config']['ports'] = {
@@ -32,8 +32,8 @@ default['consul']['config']['ports'] = {
 
 default['consul']['diplomat_version'] = nil
 
-default['consul']['service']['config_dir'] = join_path prefix_path, 'conf.d'
-default['consul']['service']['data_dir'] = join_path prefix_path, 'data'
+default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
+default['consul']['service']['data_dir'] = join_path data_prefix_path, 'data'
 
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
@@ -41,6 +41,16 @@ default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/con
 default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'
 
 default['consul']['version'] = '0.6.2'
+
+# Windows only
+default['consul']['service']['nssm_params'] = {
+  'AppDirectory'     => join_path(data_prefix_path, 'data'),
+  'AppStdout'        => join_path(config_prefix_path, 'stdout.log'),
+  'AppStderr'        => join_path(config_prefix_path, 'error.log'),
+  'AppRotateSeconds' => 86_400,
+  'AppRotateFiles'   => 1
+}
+
 default['consul']['checksums'] = {
   'consul_0.5.0_darwin_amd64'  => '24d9758c873e9124e0ce266f118078f87ba8d8363ab16c2e59a3cd197b77e964',
   'consul_0.5.0_linux_386'     => '4b6147c30596a30361d4753d409f8a1af9518f54f5ed473a4c4ac973738ac0fd',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,8 +47,9 @@ default['consul']['service']['nssm_params'] = {
   'AppDirectory'     => join_path(data_prefix_path, 'data'),
   'AppStdout'        => join_path(config_prefix_path, 'stdout.log'),
   'AppStderr'        => join_path(config_prefix_path, 'error.log'),
-  'AppRotateSeconds' => 86_400,
-  'AppRotateFiles'   => 1
+  'AppRotateFiles'   => 1,
+  'AppRotateOnline'  => 1,
+  'AppRotateBytes'   => 20_000_000
 }
 
 default['consul']['checksums'] = {

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -5,12 +5,14 @@
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
 require 'poise'
+require_relative 'helpers'
 
 module ConsulCookbook
   module Resource
     # @since 1.0.0
     class ConsulConfig < Chef::Resource
       include Poise(fused: true)
+      include ConsulCookbook::Helpers
       provides(:consul_config)
 
       # @!attribute path
@@ -114,49 +116,61 @@ module ConsulCookbook
             [new_resource.ca_file, new_resource.cert_file, new_resource.key_file].each do |filename|
               directory ::File.dirname(filename) do
                 recursive true
-                owner new_resource.owner
-                group new_resource.group
-                mode '0755'
+                if node['os'].eql? 'linux'
+                  owner new_resource.owner
+                  group new_resource.group
+                  mode '0755'
+                end
               end
             end
 
             item = chef_vault_item(new_resource.bag_name, new_resource.bag_item)
             file new_resource.ca_file do
               content item['ca_certificate']
-              mode '0644'
-              owner new_resource.owner
-              group new_resource.group
+              if node['os'].eql? 'linux'
+                owner new_resource.owner
+                group new_resource.group
+                mode '0644'
+              end
             end
 
             file new_resource.cert_file do
               content item['certificate']
-              mode '0644'
-              owner new_resource.owner
-              group new_resource.group
+              if node['os'].eql? 'linux'
+                owner new_resource.owner
+                group new_resource.group
+                mode '0644'
+              end
             end
 
             file new_resource.key_file do
               sensitive true
               content item['private_key']
-              mode '0640'
-              owner new_resource.owner
-              group new_resource.group
+              if node['os'].eql? 'linux'
+                owner new_resource.owner
+                group new_resource.group
+                mode '0640'
+              end
             end
           end
 
           directory ::File.dirname(new_resource.path) do
             recursive true
-            owner new_resource.owner
-            group new_resource.group
-            mode '0755'
+            if node['os'].eql? 'linux'
+              owner new_resource.owner
+              group new_resource.group
+              mode '0755'
+            end
             not_if { ::File.dirname(new_resource.path) == '/etc' }
           end
 
           file new_resource.path do
-            owner new_resource.owner
-            group new_resource.group
+            if node['os'].eql? 'linux'
+              owner new_resource.owner
+              group new_resource.group
+              mode '0640'
+            end
             content new_resource.to_json
-            mode '0640'
           end
         end
       end

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -11,12 +11,13 @@ module ConsulCookbook
     # @since 1.0.0
     class ConsulDefinition < Chef::Resource
       include Poise(fused: true)
+      include ConsulCookbook::Helpers
       provides(:consul_definition)
       default_action(:create)
 
       # @!attribute path
       # @return [String]
-      attribute(:path, kind_of: String, default: lazy { "/etc/consul/#{name}.json" })
+      attribute(:path, kind_of: String, default: lazy { join_path config_prefix_path, "#{name}.json" })
 
       # @!attribute user
       # @return [String]
@@ -44,16 +45,20 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            owner new_resource.user
-            group new_resource.group
-            mode '0755'
+            if node['os'].eql? 'linux'
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
           end
 
           file new_resource.path do
-            owner new_resource.user
-            group new_resource.group
             content new_resource.to_json
-            mode '0640'
+            if node['os'].eql? 'linux'
+              owner new_resource.user
+              group new_resource.group
+              mode '0640'
+            end
           end
         end
       end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -5,6 +5,7 @@
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
 require 'poise_service/service_mixin'
+require_relative 'helpers'
 
 module ConsulCookbook
   module Resource
@@ -12,8 +13,10 @@ module ConsulCookbook
     # @since 1.0.0
     class ConsulService < Chef::Resource
       include Poise
-      provides(:consul_service)
+      provides :consul_service
+      actions :enable, :disable
       include PoiseService::ServiceMixin
+      include ConsulCookbook::Helpers
 
       # @!attribute version
       # @return [String]
@@ -25,11 +28,11 @@ module ConsulCookbook
 
       # @!attribute install_path
       # @return [String]
-      attribute(:install_path, kind_of: String, default: '/srv')
+      attribute(:install_path, kind_of: String, default: lazy { windows? ? "#{program_files}\\consul" : '/srv' })
 
       # @!attribute config_file
       # @return [String]
-      attribute(:config_file, kind_of: String, default: '/etc/consul.json')
+      attribute(:config_file, kind_of: String, default: lazy { node['consul']['config']['path'] })
 
       # @!attribute user
       # @return [String]
@@ -57,131 +60,11 @@ module ConsulCookbook
 
       # @!attribute data_dir
       # @return [String]
-      attribute(:data_dir, kind_of: String, default: '/var/lib/consul')
+      attribute(:data_dir, kind_of: String, default: lazy { node['consul']['service']['data_dir'] })
 
       # @!attribute config_dir
       # @return [String]
-      attribute(:config_dir, kind_of: String, default: '/etc/consul')
-
-      def default_environment
-        {
-          'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
-          'PATH' => '/usr/local/bin:/usr/bin:/bin'
-        }
-      end
-
-      def command
-        "/usr/bin/env consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
-      end
-
-      def binary_checksum
-        node['consul']['checksums'].fetch(binary_filename)
-      end
-
-      def binary_filename
-        arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : '386'
-        ['consul', version, node['os'], arch].join('_')
-      end
-    end
-  end
-
-  module Provider
-    # Provider for managing the Consul service on an instance.
-    # @since 1.0.0
-    class ConsulService < Chef::Provider
-      include Poise
-      provides(:consul_service)
-      include PoiseService::ServiceMixin
-
-      def action_enable
-        notifying_block do
-          package new_resource.package_name do
-            version new_resource.version unless new_resource.version.nil?
-            only_if { new_resource.install_method == 'package' }
-          end
-
-          if node['platform'] == 'windows'
-            include_recipe 'chocolatey::default'
-
-            chocolatey new_resource.package_name do
-              version new_resource.version
-            end
-          end
-
-          if new_resource.install_method == 'binary'
-            artifact = libartifact_file "consul-#{new_resource.version}" do
-              artifact_name 'consul'
-              artifact_version new_resource.version
-              install_path new_resource.install_path
-              remote_url new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename }
-              remote_checksum new_resource.binary_checksum
-            end
-
-            link '/usr/local/bin/consul' do
-              to ::File.join(artifact.current_path, 'consul')
-            end
-          end
-
-          if new_resource.install_method == 'source'
-            include_recipe 'golang::default'
-
-            source_dir = directory ::File.join(new_resource.install_path, 'consul', 'src') do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-
-            git ::File.join(source_dir.path, "consul-#{new_resource.version}") do
-              repository new_resource.source_url
-              reference new_resource.version
-              action :checkout
-            end
-
-            golang_package 'github.com/hashicorp/consul' do
-              action :install
-            end
-
-            directory ::File.join(new_resource.install_path, 'bin') do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-
-            link ::File.join(new_resource.install_path, 'bin', 'consul') do
-              to ::File.join(source_dir.path, "consul-#{new_resource.version}", 'consul')
-            end
-          end
-
-          [new_resource.data_dir, new_resource.config_dir].each do |dirname|
-            directory dirname do
-              recursive true
-              owner new_resource.user
-              group new_resource.group
-              mode '0755'
-            end
-          end
-        end
-        super
-      end
-
-      def action_disable
-        notifying_block do
-          file new_resource.config_file do
-            action :delete
-          end
-        end
-        super
-      end
-
-      def service_options(service)
-        service.command(new_resource.command)
-        service.directory(new_resource.data_dir)
-        service.user(new_resource.user)
-        service.environment(new_resource.environment)
-        service.restart_on_update(true)
-      end
+      attribute(:config_dir, kind_of: String, default: lazy { node['consul']['config']['config_dir'] })
     end
   end
 end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -28,7 +28,7 @@ module ConsulCookbook
 
       # @!attribute install_path
       # @return [String]
-      attribute(:install_path, kind_of: String, default: lazy { windows? ? "#{program_files}\\consul" : '/srv' })
+      attribute(:install_path, kind_of: String, default: lazy { windows? ? prefix_path : '/srv' })
 
       # @!attribute config_file
       # @return [String]

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -28,7 +28,7 @@ module ConsulCookbook
 
       # @!attribute install_path
       # @return [String]
-      attribute(:install_path, kind_of: String, default: lazy { windows? ? prefix_path : '/srv' })
+      attribute(:install_path, kind_of: String, default: lazy { windows? ? config_prefix_path : '/srv' })
 
       # @!attribute config_file
       # @return [String]
@@ -65,6 +65,10 @@ module ConsulCookbook
       # @!attribute config_dir
       # @return [String]
       attribute(:config_dir, kind_of: String, default: lazy { node['consul']['config']['config_dir'] })
+
+      # @!attribute nssm_params
+      # @return [String]
+      attribute(:nssm_params, kind_of: Hash, default: lazy { node['consul']['service']['nssm_params'] })
     end
   end
 end

--- a/libraries/consul_service_linux.rb
+++ b/libraries/consul_service_linux.rb
@@ -1,0 +1,102 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2014, 2015 Bloomberg Finance L.P.
+#
+require 'poise_service/service_mixin'
+require_relative 'helpers'
+
+module ConsulCookbook
+  module Provider
+    # Provider for managing the Consul service on a Linux instance.
+    # @since 1.0.0
+    class ConsulServiceLinux < Chef::Provider
+      include Poise
+      provides :consul_service, os: %w(linux)
+      include PoiseService::ServiceMixin
+      include ConsulCookbook::Helpers
+
+      def action_enable
+        notifying_block do
+          case new_resource.install_method
+          when 'package'
+            package new_resource.package_name do
+              version new_resource.version unless new_resource.version.nil?
+              only_if { new_resource.install_method == 'package' }
+            end
+          when 'binary'
+            artifact = libartifact_file "consul-#{new_resource.version}" do
+              artifact_name 'consul'
+              artifact_version new_resource.version
+              install_path new_resource.install_path
+              remote_url new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename('binary') }
+              remote_checksum new_resource.binary_checksum 'binary'
+            end
+
+            link '/usr/local/bin/consul' do
+              to ::File.join(artifact.current_path, 'consul')
+            end
+          when 'source'
+            include_recipe 'golang::default'
+
+            source_dir = directory ::File.join(new_resource.install_path, 'consul', 'src') do
+              recursive true
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
+
+            git ::File.join(source_dir.path, "consul-#{new_resource.version}") do
+              repository new_resource.source_url
+              reference new_resource.version
+              action :checkout
+            end
+
+            golang_package 'github.com/hashicorp/consul' do
+              action :install
+            end
+
+            directory ::File.join(new_resource.install_path, 'bin') do
+              recursive true
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
+
+            link ::File.join(new_resource.install_path, 'bin', 'consul') do
+              to ::File.join(source_dir.path, "consul-#{new_resource.version}", 'consul')
+            end
+          end
+
+          [new_resource.data_dir, new_resource.config_dir].each do |dirname|
+            directory dirname do
+              recursive true
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
+          end
+        end
+        super
+      end
+
+      def action_disable
+        notifying_block do
+          file new_resource.config_file do
+            action :delete
+          end
+        end
+        super
+      end
+
+      def service_options(service)
+        service.command(new_resource.command new_resource.config_file, new_resource.config_dir)
+        service.directory(new_resource.data_dir)
+        service.user(new_resource.user)
+        service.environment(new_resource.environment)
+        service.restart_on_update(true)
+      end
+    end
+  end
+end

--- a/libraries/consul_service_linux.rb
+++ b/libraries/consul_service_linux.rb
@@ -35,19 +35,19 @@ module ConsulCookbook
             end
 
             link '/usr/local/bin/consul' do
-              to ::File.join(artifact.current_path, 'consul')
+              to join_path(artifact.current_path, 'consul')
             end
           when 'source'
             include_recipe 'golang::default'
 
-            source_dir = directory ::File.join(new_resource.install_path, 'consul', 'src') do
+            source_dir = directory join_path(new_resource.install_path, 'consul', 'src') do
               recursive true
               owner new_resource.user
               group new_resource.group
               mode '0755'
             end
 
-            git ::File.join(source_dir.path, "consul-#{new_resource.version}") do
+            git join_path(source_dir.path, "consul-#{new_resource.version}") do
               repository new_resource.source_url
               reference new_resource.version
               action :checkout
@@ -57,15 +57,15 @@ module ConsulCookbook
               action :install
             end
 
-            directory ::File.join(new_resource.install_path, 'bin') do
+            directory join_path(new_resource.install_path, 'bin') do
               recursive true
               owner new_resource.user
               group new_resource.group
               mode '0755'
             end
 
-            link ::File.join(new_resource.install_path, 'bin', 'consul') do
-              to ::File.join(source_dir.path, "consul-#{new_resource.version}", 'consul')
+            link join_path(new_resource.install_path, 'bin', 'consul') do
+              to join_path(source_dir.path, "consul-#{new_resource.version}", 'consul')
             end
           end
 

--- a/libraries/consul_service_linux.rb
+++ b/libraries/consul_service_linux.rb
@@ -91,7 +91,7 @@ module ConsulCookbook
       end
 
       def service_options(service)
-        service.command(new_resource.command new_resource.config_file, new_resource.config_dir)
+        service.command(new_resource.command(new_resource.config_file, new_resource.config_dir))
         service.directory(new_resource.data_dir)
         service.user(new_resource.user)
         service.environment(new_resource.environment)

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -1,0 +1,78 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2014, 2015 Bloomberg Finance L.P.
+#
+require 'poise'
+require_relative 'helpers'
+
+module ConsulCookbook
+  module Provider
+    # Provider for managing the Consul service on a Windows instance.
+    # @since 1.0.0
+    class ConsulServiceWindows < Chef::Provider
+      include Poise
+      provides :consul_service, os: %w(windows)
+      include ConsulCookbook::Helpers
+
+      def action_enable
+        notifying_block do
+          case new_resource.install_method
+          when 'binary'
+            windows_zipfile "consul-#{new_resource.version}" do
+              action :unzip
+              path new_resource.install_path
+              source new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename('binary') }
+              not_if { ::File.exist?("#{new_resource.install_path}\\consul.exe") }
+            end
+          else
+            Chef::Application.fatal!('The Consul Service provider for Windows only supports the binary install_method at this time')
+          end
+
+          [new_resource.data_dir, new_resource.config_dir].each do |dirname|
+            directory dirname do
+              recursive true
+              # owner new_resource.user
+              # group new_resource.group
+              # mode '0755'
+            end
+          end
+
+          nssm 'consul' do
+            action :install
+            program "#{new_resource.install_path}\\consul.exe"
+            params(
+              AppDirectory: new_resource.data_dir,
+              AppStdout: "#{new_resource.install_path}\\stdout.log",
+              AppStderr: "#{new_resource.install_path}\\error.log",
+              AppRotateSeconds: 86_400,
+              AppRotateFiles: 1
+            )
+            args command new_resource.config_file, new_resource.config_dir
+          end
+        end
+      end
+
+      def action_restart
+        batch 'Restart consul' do
+          code <<-EOH
+            #{nssm_exe} restart consul
+          EOH
+        end
+      end
+
+      def action_disable
+        notifying_block do
+          nssm 'consul' do
+            action :remove
+          end
+
+          file new_resource.config_file do
+            action :delete
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -13,6 +13,7 @@ module ConsulCookbook
     # @since 1.0.0
     class ConsulServiceWindows < Chef::Provider
       include Poise
+      include Chef::Mixin::ShellOut
       provides :consul_service, os: %w(windows)
       include ConsulCookbook::Helpers
 
@@ -24,7 +25,7 @@ module ConsulCookbook
               action :unzip
               path new_resource.install_path
               source new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename('binary') }
-              not_if { ::File.exist?("#{new_resource.install_path}\\consul.exe") }
+              not_if { correct_version?(join_path(new_resource.install_path, 'consul.exe'), new_resource.version) }
             end
           else
             Chef::Application.fatal!('The Consul Service provider for Windows only supports the binary install_method at this time')
@@ -41,24 +42,22 @@ module ConsulCookbook
 
           nssm 'consul' do
             action :install
-            program "#{new_resource.install_path}\\consul.exe"
+            program join_path(new_resource.install_path, 'consul.exe')
             params(
               AppDirectory: new_resource.data_dir,
-              AppStdout: "#{new_resource.install_path}\\stdout.log",
-              AppStderr: "#{new_resource.install_path}\\error.log",
+              AppStdout: join_path(new_resource.install_path, 'stdout.log'),
+              AppStderr: join_path(new_resource.install_path, 'error.log'),
               AppRotateSeconds: 86_400,
               AppRotateFiles: 1
             )
-            args command new_resource.config_file, new_resource.config_dir
+            args command(new_resource.config_file, new_resource.config_dir)
           end
         end
       end
 
       def action_restart
         batch 'Restart consul' do
-          code <<-EOH
-            #{nssm_exe} restart consul
-          EOH
+          code "#{nssm_exe} restart consul"
         end
       end
 

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -65,6 +65,14 @@ module ConsulCookbook
                 code "#{nssm_exe} restart consul"
               end
             end
+            # Check if the service is running, but don't bother if we're already
+            # changing some nssm parameters
+            unless nssm_service_running? && mismatch_params.empty?
+              batch 'Trigger consul restart' do
+                action :run
+                code "#{nssm_exe} restart consul"
+              end
+            end
           end
         end
       end

--- a/libraries/consul_ui.rb
+++ b/libraries/consul_ui.rb
@@ -5,12 +5,14 @@
 # Copyright 2014-2015, Bloomberg Finance L.P.
 #
 require 'poise'
+require_relative 'helpers'
 
 module ConsulCookbook
   module Resource
     # Resource for managing the Consul web UI installation.
     class ConsulUI < Chef::Resource
       include Poise
+      include ConsulCookbook::Helpers
       provides(:consul_ui)
       default_action(:install)
 
@@ -37,18 +39,6 @@ module ConsulCookbook
       # @!attribute source_url
       # @return [String]
       attribute(:source_url, kind_of: String)
-
-      def default_environment
-        { GOMAXPROCS: [node['cpu']['total'], 2].max.to_s, PATH: '/usr/local/bin:/usr/bin:/bin' }
-      end
-
-      def binary_checksum
-        node['consul']['checksums'].fetch(binary_filename)
-      end
-
-      def binary_filename
-        ['consul', version, 'web_ui'].join('_')
-      end
     end
   end
 
@@ -66,8 +56,8 @@ module ConsulCookbook
             owner new_resource.owner
             group new_resource.group
             install_path new_resource.install_path
-            remote_url new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename }
-            remote_checksum new_resource.binary_checksum
+            remote_url new_resource.binary_url % { version: new_resource.version, filename: new_resource.binary_filename('web_ui') }
+            remote_checksum new_resource.binary_checksum 'web_ui'
           end
         end
       end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright (C) 2015 Bloomberg Finance L.P.
+#
+
+module ConsulCookbook
+  module Helpers
+    extend self
+
+    def arch_64?
+      node['kernel']['machine'] =~ /x86_64/ ? true : false
+    end
+
+    def windows?
+      node['os'].eql?('windows') ? true : false
+    end
+
+    def program_files
+      'C:\\Program Files' + (arch_64? ? '' : ' x(86)')
+    end
+
+    def default_environment
+      {
+        'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
+        'PATH' => '/usr/local/bin:/usr/bin:/bin'
+      }
+    end
+
+    def command(config_file, config_dir)
+      if windows?
+        %{agent -config-file="""#{config_file}""" -config-dir="""#{config_dir}"""}
+      else
+        "/usr/bin/env consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
+      end
+    end
+
+    def binary_checksum(item)
+      node['consul']['checksums'].fetch(binary_filename item)
+    end
+
+    def binary_filename(item)
+      case item
+      when 'binary'
+        arch = arch_64? ? 'amd64' : '386'
+        ['consul', version, node['os'], arch].join('_')
+      when 'web_ui'
+        ['consul', version, 'web_ui'].join('_')
+      end
+    end
+
+    def nssm_exe
+      "#{node['nssm']['install_location']}\\nssm.exe"
+    end
+  end
+end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -7,6 +7,8 @@
 
 module ConsulCookbook
   module Helpers
+    include Chef::Mixin::ShellOut
+
     extend self
 
     def arch_64?
@@ -17,15 +19,25 @@ module ConsulCookbook
       node['os'].eql?('windows') ? true : false
     end
 
-    def program_files
-      'C:\\Program Files' + (arch_64? ? '' : ' x(86)')
+    # returns windows friendly version of the provided path,
+    # ensures backslashes are used everywhere
+    # Gently plucked from https://github.com/chef-cookbooks/windows
+    def win_friendly_path(path)
+      path.gsub(::File::SEPARATOR, ::File::ALT_SEPARATOR || '\\') if path
     end
 
-    def default_environment
-      {
-        'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
-        'PATH' => '/usr/local/bin:/usr/bin:/bin'
-      }
+    # Simply using ::File.join was causing several attributes
+    # to return strange values in the resources (e.g. "C:/Program Files/\\consul\\data")
+    def join_path(*path)
+      windows? ? win_friendly_path(::File.join(path)) : ::File.join(path)
+    end
+
+    def program_files
+      join_path('C:', 'Program Files') + (arch_64? ? '' : ' x(86)')
+    end
+
+    def prefix_path
+      windows? ? join_path(program_files, 'consul') : join_path('/etc', 'consul')
     end
 
     def command(config_file, config_dir)
@@ -34,6 +46,11 @@ module ConsulCookbook
       else
         "/usr/bin/env consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end
+    end
+
+    # 1 is command not found
+    def correct_version?(executable, version)
+      shell_out!(%{"#{executable}" version}, returns: [0, 1]).stdout.match version
     end
 
     def binary_checksum(item)
@@ -52,6 +69,13 @@ module ConsulCookbook
 
     def nssm_exe
       "#{node['nssm']['install_location']}\\nssm.exe"
+    end
+
+    def default_environment
+      {
+        'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
+        'PATH' => '/usr/local/bin:/usr/bin:/bin'
+      }
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -58,7 +58,7 @@ module ConsulCookbook
     end
 
     def binary_checksum(item)
-      node['consul']['checksums'].fetch(binary_filename item)
+      node['consul']['checksums'].fetch(binary_filename(item))
     end
 
     def binary_filename(item)
@@ -127,7 +127,9 @@ module ConsulCookbook
     end
 
     def nssm_service_installed?
-      exit_code = shell_out!(%{"#{nssm_exe}" status consul}, returns: [0, 3]).exitstatus
+      # 1 is command not found
+      # 3 is service not found
+      exit_code = shell_out!(%{"#{nssm_exe}" status consul}, returns: [0, 1, 3]).exitstatus
       exit_code == 0 ? true : false
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -133,6 +133,10 @@ module ConsulCookbook
       exit_code == 0 ? true : false
     end
 
+    def nssm_service_running?
+      shell_out!(%{"#{nssm_exe}" status consul}, returns: [0]).stdout.delete("\0").strip.eql? 'SERVICE_RUNNING'
+    end
+
     # Returns a hash of mismatched params
     def check_nssm_params
       # nssm can only get certain values

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ supports 'arch'
 supports 'windows'
 
 depends 'chef-vault', '~> 1.3'
-depends 'chocolatey'
+depends 'nssm'
 depends 'golang'
 depends 'firewall', '~> 2.0'
 depends 'libartifact', '~> 1.3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,38 +5,50 @@
 # Copyright 2014-2015, Bloomberg Finance L.P.
 #
 
+node.default['nssm']['install_location'] = '%WINDIR%'
+
 if node['firewall']['allow_consul']
   include_recipe 'firewall::default'
 
+  # Don't open ports that we've disabled
+  ports = node['consul']['config']['ports'].select { |_name, port| port != -1 }
+
   firewall_rule 'consul' do
     protocol :tcp
-    port node['consul']['config']['ports'].values
+    port ports.values
     action :create
     command :allow
   end
 
   firewall_rule 'consul-udp' do
     protocol :udp
-    port node['consul']['config']['ports'].values_at('serf_lan', 'serf_wan', 'dns')
+    port ports.values_at('serf_lan', 'serf_wan', 'dns')
     action :create
     command :allow
   end
 end
 
-poise_service_user node['consul']['service_user'] do
-  group node['consul']['service_group']
+# NSSM will run Consul as the SYSTEM account
+if node['os'].eql? 'linux'
+  poise_service_user node['consul']['service_user'] do
+    group node['consul']['service_group']
+  end
 end
 
 config = consul_config node['consul']['service_name'] do |r|
-  owner node['consul']['service_user']
-  group node['consul']['service_group']
+  if node['os'].eql? 'linux'
+    owner node['consul']['service_user']
+    group node['consul']['service_group']
+  end
 
   node['consul']['config'].each_pair { |k, v| r.send(k, v) }
 end
 
 consul_service node['consul']['service_name'] do |r|
-  user node['consul']['service_user']
-  group node['consul']['service_group']
+  if node['os'].eql? 'linux'
+    user node['consul']['service_user']
+    group node['consul']['service_group']
+  end
   version node['consul']['version']
   config_file config.path
 

--- a/test/spec/libraries/consul_service_linux_spec.rb
+++ b/test/spec/libraries/consul_service_linux_spec.rb
@@ -9,6 +9,6 @@ describe ConsulCookbook::Resource::ConsulService do
     recipe 'consul::default'
 
     it { expect(chef_run).to create_directory('/etc/consul/conf.d') }
-    it { is_expected.to create_directory('/var/lib/consul') }
+    it { is_expected.to create_directory('/etc/consul/data') }
   end
 end

--- a/test/spec/libraries/consul_service_linux_spec.rb
+++ b/test/spec/libraries/consul_service_linux_spec.rb
@@ -8,7 +8,7 @@ describe ConsulCookbook::Resource::ConsulService do
   context 'with default properties' do
     recipe 'consul::default'
 
-    it { expect(chef_run).to create_directory('/etc/consul') }
+    it { expect(chef_run).to create_directory('/etc/consul/conf.d') }
     it { is_expected.to create_directory('/var/lib/consul') }
   end
 end

--- a/test/spec/libraries/consul_service_linux_spec.rb
+++ b/test/spec/libraries/consul_service_linux_spec.rb
@@ -9,6 +9,6 @@ describe ConsulCookbook::Resource::ConsulService do
     recipe 'consul::default'
 
     it { expect(chef_run).to create_directory('/etc/consul/conf.d') }
-    it { is_expected.to create_directory('/etc/consul/data') }
+    it { is_expected.to create_directory('/var/lib/consul/data') }
   end
 end

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -3,9 +3,20 @@ require_relative '../../../libraries/consul_service'
 
 describe ConsulCookbook::Resource::ConsulService do
   step_into(:consul_service)
-  let(:chefspec_options) { {platform: 'windows', version: '2012R2'} }
+  let(:chefspec_options) { { platform: 'windows', version: '2012R2'} }
+  let(:shellout) { double('shellout') }
 
   context 'with default properties' do
+    before do
+      Mixlib::ShellOut.stub(:new).and_return(shellout)
+      allow(shellout).to receive(:live_stream)
+      allow(shellout).to receive(:live_stream=)
+      allow(shellout).to receive(:error!)
+      allow(shellout).to receive(:stderr)
+      allow(shellout).to receive(:run_command)
+      allow(shellout).to receive(:stdout).and_return("Consul v0.6.0\nConsul Protocol: 3 (Understands back to: 1)\n")
+    end
+
     recipe 'consul::default'
 
     it { expect(chef_run).to create_directory('C:\Program Files\consul\conf.d') }

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require_relative '../../../libraries/consul_service'
+
+describe ConsulCookbook::Resource::ConsulService do
+  step_into(:consul_service)
+  let(:chefspec_options) { {platform: 'windows', version: '2012R2'} }
+
+  context 'with default properties' do
+    recipe 'consul::default'
+
+    it { expect(chef_run).to create_directory('C:\Program Files\consul\conf.d') }
+    it { is_expected.to create_directory('C:\Program Files\consul\data') }
+    it { expect(chef_run).to install_nssm('consul').with(
+      program: 'C:\Program Files\consul\consul.exe',
+      args: 'agent -config-file="""C:\Program Files\consul\consul.json""" -config-dir="""C:\Program Files\consul\conf.d"""'
+    )}
+  end
+end

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -14,6 +14,7 @@ describe ConsulCookbook::Resource::ConsulService do
       allow(shellout).to receive(:error!)
       allow(shellout).to receive(:stderr)
       allow(shellout).to receive(:run_command)
+      allow(shellout).to receive(:exitstatus)
       allow(shellout).to receive(:stdout).and_return("Consul v0.6.0\nConsul Protocol: 3 (Understands back to: 1)\n")
     end
 

--- a/test/spec/libraries/consul_ui_spec.rb
+++ b/test/spec/libraries/consul_ui_spec.rb
@@ -3,12 +3,14 @@ require_relative '../../../libraries/consul_ui'
 
 describe ConsulCookbook::Resource::ConsulUI do
   step_into(:consul_ui)
+  let(:chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
 
   context 'consul ui install' do
     recipe 'consul_spec::consul_ui'
 
     it do is_expected.to create_libartifact_file('myconsul-ui-0.5.1')
-      .with(owner: 'myconsul',group: 'myconsul',
+      .with(owner: 'myconsul',
+            group: 'myconsul',
             remote_url: "https://releases.hashicorp.com/consul/0.5.1/consul_0.5.1_web_ui.zip",
             install_path: '/opt')
     end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'poise_boiler/spec_helper'
+require_relative '../../libraries/helpers'
 require_relative('support/chefspec_extensions/automatic_resource_matcher')


### PR DESCRIPTION
* Fixes #236
* Added Windows Support (binary install_method only) using NSSM
  to manage the service. NSSM runs consul as the local SYSTEM user.
  Support for running it as another user can/should be added later.
* Prevented the firewall cookbook from creating rules for disabled
  ports
* Added & Updated spec tests
* Disabled Style/ModuleFunction cop
* Simplified how attributes with paths for values are set
* Added version check to windows binary installation so that it can
  be upgraded