### PR TITLE
Added ability to remove nssm parameters

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,8 @@ default['consul']['config']['ports'] = {
 default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
+
+default['consul']['service']['install_path'] = windows? ? config_prefix_path : '/srv'
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,7 @@ default['consul']['config']['bag_name'] = 'secrets'
 default['consul']['config']['bag_item'] = 'consul'
 
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
-default['consul']['config']['data_dir'] = join_path data_prefix_path, 'data'
+default['consul']['config']['data_dir'] = data_prefix_path
 default['consul']['config']['ca_file'] = join_path config_prefix_path, 'ssl', 'CA', 'ca.crt'
 default['consul']['config']['cert_file'] = join_path config_prefix_path, 'ssl', 'certs', 'consul.crt'
 default['consul']['config']['key_file'] = join_path config_prefix_path, 'ssl', 'private', 'consul.key'

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -27,7 +27,7 @@ module ConsulCookbook
 
       # @!attribute install_path
       # @return [String]
-      attribute(:install_path, kind_of: String, default: lazy { windows? ? config_prefix_path : '/srv' })
+      attribute(:install_path, kind_of: String, default: lazy { node['consul']['service']['install_path'] })
 
       # @!attribute config_file
       # @return [String]

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -81,7 +81,6 @@ module ConsulCookbook
       include ConsulCookbook::Helpers
 
       def action_enable
-        new_resource.notifies(:reload, new_resource, :delayed)
         notifying_block do
           case new_resource.install_method
           when 'package'

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -72,7 +72,7 @@ module ConsulCookbook
             end
             # Check if the service is running, but don't bother if we're already
             # changing some nssm parameters
-            unless nssm_service_running? && mismatch_params.empty?
+            unless nssm_service_status?(%w{SERVICE_RUNNING}) && mismatch_params.empty?
               batch 'Trigger consul restart' do
                 action :run
                 code "#{nssm_exe} restart consul"
@@ -94,7 +94,7 @@ module ConsulCookbook
           batch 'Stop consul' do
             action :run
             code "#{nssm_exe} stop consul"
-            only_if { nssm_service_installed? && nssm_service_running? }
+            only_if { nssm_service_installed? && nssm_service_status?(%w{SERVICE_RUNNING SERVICE_PAUSED}) }
           end
 
           nssm 'consul' do

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -52,6 +52,7 @@ module ConsulCookbook
             # Don't try and set empty parameters
             params new_resource.nssm_params.select { |_k, v| v != '' }
             args command(new_resource.config_file, new_resource.config_dir)
+            not_if { nssm_service_installed? }
           end
 
           if nssm_service_installed?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -133,8 +133,8 @@ module ConsulCookbook
       exit_code == 0 ? true : false
     end
 
-    def nssm_service_running?
-      shell_out!(%{"#{nssm_exe}" status consul}, returns: [0]).stdout.delete("\0").strip.eql? 'SERVICE_RUNNING'
+    def nssm_service_status?(expected_status)
+      expected_status.include? shell_out!(%{"#{nssm_exe}" status consul}, returns: [0]).stdout.delete("\0").strip
     end
 
     # Returns a hash of mismatched params

--- a/test/spec/libraries/consul_service_linux_spec.rb
+++ b/test/spec/libraries/consul_service_linux_spec.rb
@@ -9,6 +9,6 @@ describe ConsulCookbook::Resource::ConsulService do
     recipe 'consul::default'
 
     it { expect(chef_run).to create_directory('/etc/consul/conf.d') }
-    it { is_expected.to create_directory('/var/lib/consul/data') }
+    it { is_expected.to create_directory('/var/lib/consul') }
   end
 end

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -21,7 +21,7 @@ describe ConsulCookbook::Resource::ConsulService do
     recipe 'consul::default'
 
     it { expect(chef_run).to create_directory('C:\Program Files\consul\conf.d') }
-    it { is_expected.to create_directory('C:\Program Files\consul\data') }
+    it { is_expected.to create_directory('C:\Program Files\consul') }
     it { expect(chef_run).to install_nssm('consul').with(
       program: 'C:\Program Files\consul\consul.exe',
       args: 'agent -config-file="""C:\Program Files\consul\consul.json""" -config-dir="""C:\Program Files\consul\conf.d"""'


### PR DESCRIPTION
* You can now remove previously set nssm parameters by setting the hash values to `''` for Strings, & `0` for Integers. Also improved how the Consul service is stopped on Windows. If you don't stop it before you remove it, you end up in a SERVICE_PAUSED state.
* Fixes #262
* Fixed an edge case when stopping the service on Windows
* Removed problematic reload line. `new_resource.notifies(:reload, new_resource, :delayed)` causes the `consul_service` resource to reload every time Chef ran. This is an issue with the new sysvinit service provider when the service is in a stopped state when Chef runs. It would start and recieve a reload HUP too quickly & subsequently crash the service.
* Added attribute for specifying install_path for `consul_service` resource. My reasoning is that one should be able to change this crucial property without having to redeclare the whole resource.