### PR TITLE
Add custom template for "sysvinit" service provider

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -161,6 +161,7 @@ module ConsulCookbook
         service.environment(new_resource.environment)
         service.restart_on_update(true)
         service.options(:systemd, template: 'consul:systemd.service.erb')
+        service.options(:sysvinit, template: 'consul:sysvinit.service.erb')
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -48,7 +48,7 @@ module ConsulCookbook
       if windows?
         %{agent -config-file="""#{config_file}""" -config-dir="""#{config_dir}"""}
       else
-        "/usr/bin/env consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
+        "consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end
     end
 

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -1,0 +1,131 @@
+#!/bin/sh
+#
+# <%= @name %> - this script manages the consul agent
+#
+### BEGIN INIT INFO
+# Provides:       <%= @name %>
+# Required-Start: $local_fs $network
+# Required-Stop:  $local_fs $network
+# Default-Start: 3 4 5
+# Default-Stop:  0 1 2 6
+# Short-Description: Manage the consul agent
+### END INIT INFO
+
+prog="<%= File.basename(@daemon) %>"
+user="<%= @user %>"
+exec="<%= @daemon %>"
+pidfile="<%= @pid_file %>"
+lockfile="/var/lock/subsys/$prog"
+
+<%- @environment.each do |key, val| -%>
+export <%= key %>="<%= val %>"
+<%- end -%>
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
+
+<%- if @platform_family == 'debian' -%>
+. /lib/lsb/init-functions
+
+_start() {
+  start-stop-daemon --start --quiet --background \
+      --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
+      --chuid $user --chdir "<%= @directory %>" \
+      --exec $exec -- <%= @daemon_options %>
+}
+
+_stop() {
+  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @stop_signal %>"
+}
+
+_status() {
+  status_of_proc -p $pidfile $exec $prog
+}
+
+_reload() {
+  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @reload_signal %>"
+}
+
+<%- else -%>
+. /etc/rc.d/init.d/functions
+
+_start() {
+    [ -x $exec ] || exit 5
+
+    umask 077
+    touch $pidfile
+    chown $user $pidfile
+
+    echo -n $"Starting <%= @name %>: "
+    daemon \
+         --pidfile=$pidfile \
+         --user=$user \
+         " { $exec <%= @daemon_options %> &> /dev/null & } ; echo \$! >| $pidfile "
+     RETVAL=$?
+     echo
+     [ $RETVAL -eq 0 ] && touch $lockfile
+     return $RETVAL
+}
+
+_stop() {
+    echo -n $"Stopping <%= @name %>: "
+    killproc -p $pidfile $exec -<%= @stop_signal %>
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f $lockfile $pidfile
+    return $RETVAL
+}
+
+_status() {
+    status -p $pidfile -l $prog $exec
+}
+
+_reload() {
+    echo -n $"Reloading <%= @name %>: "
+    killproc -p $pidfile $exec -<%= @reload_signal %>
+    echo
+}
+<%- end -%>
+
+_restart() {
+    _stop
+    while :
+    do
+        ss -pl | fgrep "((\"$prog\"," > /dev/null
+        [ $? -ne 0 ] && break
+        sleep 0.1
+    done
+    _start
+}
+
+_status_q() {
+    _status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        _status_q && exit 0
+        _start
+        ;;
+    stop)
+        _status_q || exit 0
+        _stop
+        ;;
+    restart|force-reload)
+        _restart
+        ;;
+    reload)
+        _status_q || exit 7
+        _reload
+        ;;
+    status)
+        _status
+        ;;
+    condrestart|try-restart)
+        _status_q || exit 0
+        _restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart|reload|force-reload}"
+        exit 2
+esac
+
+exit $?


### PR DESCRIPTION
The default template looks very tricky and it doesn't work well on RHEL 6: there are some artifacts in the console output while we are doing `service consul <stop | start>`:
https://github.com/poise/poise-service/blob/d9a5135dbe5711214c377c8ee2e7af029b1f10b7/chef/templates/default/sysvinit.sh.erb


This PR adds a custom template for `sysvinit` provider which looks pretty clear and works fine.
It was inspired by the init script form "consul-rpm" project: [consul.init](https://github.com/tomhillable/consul-rpm/blob/4f93c54a09067765418bd8c05926e816e610c1e8/SOURCES/consul.init)

Verified on CentOS 6.7 and Debian 7.9

P.s. This PR could be related to https://github.com/johnbellone/consul-cookbook/issues/235, but it doesn't fix this issue. For  RHEL/CentOS 6 we still have to set provider to `:sysvinit` in explicit to avoid the usage of `:upstart` (https://github.com/johnbellone/consul-cookbook/issues/235#issuecomment-172462543).