### PR TITLE
Added retry WAN parameters

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -75,7 +75,9 @@ module ConsulCookbook
       attribute(:recursor, kind_of: String)
       attribute(:recursors, kind_of: Array)
       attribute(:retry_interval, kind_of: String)
+      attribute(:retry_interval_wan, kind_of: String)
       attribute(:retry_join, kind_of: Array)
+      attribute(:retry_join_wan, kind_of: Array)
       attribute(:rejoin_after_leave, equal_to: [true, false], default: true)
       attribute(:server, equal_to: [true, false], default: true)
       attribute(:server_name, kind_of: String)
@@ -95,7 +97,7 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recursor recursors retry_interval retry_join rejoin_after_leave server server_name skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr syslog_facility ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
+        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recursor recursors retry_interval retry_interval_wan retry_join retry_join_wan rejoin_after_leave server server_name skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr syslog_facility ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
         for_keeps << %i{ca_file cert_file key_file} if tls?
         for_keeps = for_keeps.flatten
 


### PR DESCRIPTION
Added `retry_join_wan` and `retry_interval_wan` so that WAN addresses can be set at start up