### PR TITLE
Fixes #262 for Windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['consul']['diplomat_version'] = nil
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
 default['consul']['service']['data_dir'] = join_path data_prefix_path, 'data'
 
+default['consul']['service']['install_path'] = windows? ? config_prefix_path : '/srv'
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
 

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -7,7 +7,6 @@
 require 'poise_service/service_mixin'
 require_relative 'helpers'
 
-
 module ConsulCookbook
   module Resource
     # A resource for managing the Consul service.

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -27,7 +27,7 @@ module ConsulCookbook
 
       # @!attribute install_path
       # @return [String]
-      attribute(:install_path, kind_of: String, default: lazy { windows? ? config_prefix_path : '/srv' })
+      attribute(:install_path, kind_of: String, default: lazy { node['consul']['service']['install_path'] })
 
       # @!attribute config_file
       # @return [String]

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -7,7 +7,6 @@
 require 'poise'
 require_relative 'helpers'
 
-
 module ConsulCookbook
   module Provider
     # Provider for managing the Consul service on a Windows instance.
@@ -32,10 +31,13 @@ module ConsulCookbook
             Chef::Application.fatal!('The Consul Service provider for Windows only supports the binary install_method at this time')
           end
 
-          %W{#{new_resource.data_dir}
-             #{new_resource.config_dir}
-             #{::File.dirname(new_resource.nssm_params['AppStdout'])}
-             #{::File.dirname(new_resource.nssm_params['AppStderr'])}}.uniq.each do |dirname|
+          directories = %W{#{new_resource.data_dir}
+                           #{new_resource.config_dir}
+                           #{::File.dirname(new_resource.nssm_params['AppStdout'])}
+                           #{::File.dirname(new_resource.nssm_params['AppStderr'])}}.uniq.compact
+
+          # ::File.dirname '' == '.'
+          directories.delete_if { |i| i.eql? '.' }.each do |dirname|
             directory dirname do
               recursive true
               # owner new_resource.user
@@ -47,7 +49,8 @@ module ConsulCookbook
           nssm 'consul' do
             action :install
             program join_path(new_resource.install_path, 'consul.exe')
-            params new_resource.nssm_params
+            # Don't try and set empty parameters
+            params new_resource.nssm_params.select { |_k, v| v != '' }
             args command(new_resource.config_file, new_resource.config_dir)
           end
 
@@ -56,8 +59,9 @@ module ConsulCookbook
             mismatch_params = check_nssm_params
             unless mismatch_params.empty?
               mismatch_params.each do |k, v|
+                action = v.eql?('') ? "reset consul #{k}" : "set consul #{k} #{v}"
                 batch "Set nssm parameter - #{k}" do
-                  code "#{nssm_exe} set consul #{k} #{v}"
+                  code "#{nssm_exe} #{action}"
                   notifies :run, 'batch[Trigger consul restart]', :delayed
                 end
               end
@@ -86,6 +90,13 @@ module ConsulCookbook
 
       def action_disable
         notifying_block do
+          # nssm resource doesn't stop the service before it removes it
+          batch 'Stop consul' do
+            action :run
+            code "#{nssm_exe} stop consul"
+            only_if { nssm_service_installed? && nssm_service_running? }
+          end
+
           nssm 'consul' do
             action :remove
           end

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -72,7 +72,7 @@ module ConsulCookbook
             end
             # Check if the service is running, but don't bother if we're already
             # changing some nssm parameters
-            unless nssm_service_running? && mismatch_params.empty?
+            unless nssm_service_status?(%w{SERVICE_RUNNING}) && mismatch_params.empty?
               batch 'Trigger consul restart' do
                 action :run
                 code "#{nssm_exe} restart consul"
@@ -94,7 +94,7 @@ module ConsulCookbook
           batch 'Stop consul' do
             action :run
             code "#{nssm_exe} stop consul"
-            only_if { nssm_service_installed? && nssm_service_running? }
+            only_if { nssm_service_installed? && nssm_service_status?(%w{SERVICE_RUNNING SERVICE_PAUSED}) }
           end
 
           nssm 'consul' do

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -52,6 +52,7 @@ module ConsulCookbook
             # Don't try and set empty parameters
             params new_resource.nssm_params.select { |_k, v| v != '' }
             args command(new_resource.config_file, new_resource.config_dir)
+            not_if { nssm_service_installed? }
           end
 
           if nssm_service_installed?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -133,8 +133,8 @@ module ConsulCookbook
       exit_code == 0 ? true : false
     end
 
-    def nssm_service_running?
-      shell_out!(%{"#{nssm_exe}" status consul}, returns: [0]).stdout.delete("\0").strip.eql? 'SERVICE_RUNNING'
+    def nssm_service_status?(expected_status)
+      expected_status.include? shell_out!(%{"#{nssm_exe}" status consul}, returns: [0]).stdout.delete("\0").strip
     end
 
     # Returns a hash of mismatched params

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which installs and configures Consul.'
 long_description 'Application cookbook which installs and configures Consul.'
-version '1.3.1'
+version '1.4.0'
 
 recipe 'consul::default', 'Installs, configures and starts the Consul service.'
 


### PR DESCRIPTION
It appears the nssm resource also isn't idempotent. I also added another
attribute and made it the default value for the install_path property for
consul_service. My reasoning is that one should be able to change this
crucial property without having to redeclare the whole resource. #262 will
be fixed for linux once
https://github.com/johnbellone/libartifact-cookbook/pull/2 is merged