### PR TITLE
Remove duplicated "data_dir" attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,8 +33,6 @@ default['consul']['config']['ports'] = {
 default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
-default['consul']['service']['data_dir'] = join_path data_prefix_path, 'data'
-
 default['consul']['service']['install_method'] = 'binary'
 default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/consul/%{version}/%{filename}.zip" # rubocop:disable Style/StringLiterals
 

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -59,7 +59,7 @@ module ConsulCookbook
 
       # @!attribute data_dir
       # @return [String]
-      attribute(:data_dir, kind_of: String, default: lazy { node['consul']['service']['data_dir'] })
+      attribute(:data_dir, kind_of: String, default: lazy { node['consul']['config']['data_dir'] })
 
       # @!attribute config_dir
       # @return [String]


### PR DESCRIPTION
I guess it was just a typo in #259
We already have `['config']['data_dir']`, so `['service']['data_dir']` is not needed. 

Otherwise it could cause a Consul agent start failure if you override only the one of these attributes.

cc: @Ginja 