### PR TITLE
Fix "ConsulAcl" provider when specified "id" doesn't exist

### DIFF
--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -85,7 +85,7 @@ module ConsulCookbook
 
       def up_to_date?
         old_acl = Diplomat::Acl.info(new_resource.to_acl['ID'], nil, :return)
-        return false if old_acl.nil?
+        return false if old_acl.nil? || old_acl.empty?
         old_acl.first.select! { |k, _v| %w(ID Type Name Rules).include?(k) }
         old_acl.first == new_resource.to_acl
       end


### PR DESCRIPTION
If the token ID doesn't exist, `Diplomat::Acl#info` returns an empty array and it causes an error:

```
           ================================================================================
       Error executing action `create` on resource 'consul_acl[vault]'
           ================================================================================

           NoMethodError
           -------------
           undefined method `select!' for nil:NilClass

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/consul/libraries/consul_acl.rb:89:in `up_to_date?'
           /tmp/kitchen/cache/cookbooks/consul/libraries/consul_acl.rb:56:in `action_create'
```

This PR fixes that issue.