### PR TITLE
Replace nssm restart by powershell commands

### DIFF
--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -63,20 +63,19 @@ module ConsulCookbook
                 action = v.eql?('') ? "reset consul #{k}" : "set consul #{k} #{v}"
                 batch "Set nssm parameter - #{k}" do
                   code "#{nssm_exe} #{action}"
-                  notifies :run, 'batch[Trigger consul restart]', :delayed
+                  notifies :run, 'powershell_script[Trigger consul restart]', :delayed
                 end
               end
-              batch 'Trigger consul restart' do
+              powershell_script 'Trigger consul restart' do
                 action :nothing
-                code "#{nssm_exe} restart consul"
+                code "restart-service consul"
               end
             end
             # Check if the service is running, but don't bother if we're already
             # changing some nssm parameters
             unless nssm_service_status?(%w{SERVICE_RUNNING}) && mismatch_params.empty?
-              batch 'Trigger consul restart' do
-                action :run
-                code "#{nssm_exe} restart consul"
+              powershell_script 'Trigger consul restart' do
+                code "restart-service consul"
               end
             end
           end
@@ -84,17 +83,17 @@ module ConsulCookbook
       end
 
       def action_restart
-        batch 'Restart consul' do
-          code "#{nssm_exe} restart consul"
+        powershell_script 'Restart consul' do
+          code "restart-service consul"
         end
       end
 
       def action_disable
         notifying_block do
           # nssm resource doesn't stop the service before it removes it
-          batch 'Stop consul' do
+          powershell_script 'Stop consul' do
             action :run
-            code "#{nssm_exe} stop consul"
+            code "stop-service consul"
             only_if { nssm_service_installed? && nssm_service_status?(%w{SERVICE_RUNNING SERVICE_PAUSED}) }
           end
 


### PR DESCRIPTION
Very frequenty nssm commands (stop and start) fail because the service
gets into STOP_PENDING or START_PENDING state.
powershell commandlets such as restart-service have the good taste to
wait for the service to stop/start completely.