### PR TITLE
GH-277 - Adding in atlas centric configuration options

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -80,3 +80,17 @@ suites:
           nssm_params:
             AppStdout: C:\foo\bar\out.log
             AppStderr: C:\foo\bar\err.log
+  # - name: atlas
+  #   excludes:
+  #     - windows-2012r2
+  #   run_list:
+  #     - recipe[consul::default]
+  #   attributes:
+  #     consul:
+  #       config:
+  #         bootstrap: true
+  #         server: true
+  #         datacenter: fortmeade
+  #         atlas_join: true
+  #         atlas_infrastructure: <%= ENV.fetch('ATLAS_INFRASTRUCTURE', 'example/cluster') %>
+  #         atlas_token: <%= ENV.fetch('ATLAS_TOKEN', 'NOT_REAL') %>

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -49,6 +49,11 @@ module ConsulCookbook
       attribute(:addresses, kind_of: [Hash, Mash])
       attribute(:advertise_addr, kind_of: String)
       attribute(:advertise_addr_wan, kind_of: String)
+      attribute(:atlas_acl_token, kind_of: String)
+      attribute(:atlas_infrastructure, kind_of: String)
+      attribute(:atlas_join, equal_to: [true, false], default: false)
+      attribute(:atlas_token, kind_of: String)
+      attribute(:atlas_endpoint, kind_of: String)
       attribute(:bind_addr, kind_of: String)
       attribute(:bootstrap, equal_to: [true, false], default: false)
       attribute(:bootstrap_expect, kind_of: Integer, default: 3)
@@ -97,7 +102,7 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recursor recursors retry_interval retry_interval_wan retry_join retry_join_wan rejoin_after_leave server server_name skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr syslog_facility ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
+        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name ports protocol recursor recursors retry_interval retry_interval_wan retry_join retry_join_wan rejoin_after_leave server server_name skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr syslog_facility ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches}
         for_keeps << %i{ca_file cert_file key_file} if tls?
         for_keeps = for_keeps.flatten
 


### PR DESCRIPTION
Fixes #277 - Adding in Atlas parameters. 

NOTE: There doesn't seem to be a huge push towards testing every attribute in the cookbook, however I did add in the Kitchen test that is essentially essentially what you had before the rewrite due to the lack of insight into the CI process.  I commented this out due to my lack of understanding of the CI environment and if the Atlas env. variables could be relied on. 

If you'd like, I can "enable" the atlas suite, which runs via Kitchen appropriately and integrates with Atlas as expected