### PR TITLE
changing the consul_definition tags to an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ consul_definition 'vault' do
   parameters(
     port:  8200,
     address: '127.0.0.1',
-    tags: 'vault, http',
+    tags: ['vault', 'http'],
     check: {
       interval: '10s',
       timeout: '5s',


### PR DESCRIPTION
I have realised that the tags that I had written in the consul_defition are supposed to be an array so the example was partially wrong. Here is an update to fix it. 