### PR TITLE
Add support for writing logs to /var/log/consul.log.

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -18,6 +18,7 @@ prog="<%= File.basename(@daemon) %>"
 user="<%= @user %>"
 exec="<%= @daemon %>"
 pidfile="<%= @pid_file %>"
+logfile="/var/log/$prog.log"
 lockfile="/var/lock/subsys/$prog"
 
 <%- @environment.each do |key, val| -%>
@@ -61,7 +62,7 @@ _start() {
     daemon \
          --pidfile=$pidfile \
          --user=$user \
-         " { $exec <%= @daemon_options %> &> /dev/null & } ; echo \$! >| $pidfile "
+         " { $exec <%= @daemon_options %> &> $logfile & } ; echo \$! >| $pidfile "
      RETVAL=$?
      echo
      [ $RETVAL -eq 0 ] && touch $lockfile


### PR DESCRIPTION
I am not sure how this was missed before. This change for sysvinit
writes the service logs out to /var/log/consul.log.

This should close #284 and close #290.