### PR TITLE
Add debian-7.9 and debian-7.2 to the test matrix.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,12 @@ platforms:
   - name: ubuntu-12.04
     run_list:
       - recipe[apt::default]
+  - name: debian-8.2
+    run_list:
+      - recipe[apt::default]
+  - name: debian-7.9
+    run_list:
+      - recipe[apt::default]
   - name: centos-7.2
     run_list:
       - recipe[yum::default]

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -30,10 +30,12 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 . /lib/lsb/init-functions
 
 _start() {
+  touch $logfile
+  chown $user $logfile
   start-stop-daemon --start --quiet --background \
       --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
       --chuid $user --chdir "<%= @directory %>" \
-      --exec $exec -- <%= @daemon_options %>
+      --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >$logfile 2>&1"
 }
 
 _stop() {


### PR DESCRIPTION
This fixes issue with start-stop-daemon and writing logs. 