### PR TITLE
Moved user creation into separate recipe.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,17 +33,7 @@ if node['firewall']['allow_consul']
   end
 end
 
-unless windows?
-  group node['consul']['service_group'] do
-    system true
-  end
-
-  user node['consul']['service_user'] do
-    shell '/bin/bash'
-    group node['consul']['service_group']
-    system true
-  end
-end
+include_recipe 'consul::user'
 
 service_name = node['consul']['service_name']
 config = consul_config service_name do |r|

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook: consul
+# License: Apache 2.0
+#
+# Copyright 2014-2016, Bloomberg Finance L.P.
+#
+
+unless windows?
+  group node['consul']['service_group'] do
+    system true
+  end
+
+  user node['consul']['service_user'] do
+    shell '/bin/bash'
+    group node['consul']['service_group']
+    system true
+  end
+end


### PR DESCRIPTION
This makes it much eaier to write wrapper cookbooks which need to create
config files owned by teh correct user. By having the users in a separate
recipe they can iclude that and get the user created before they create
the files. But still get the files created before consul is started.