### PR TITLE
Fix log file permissions on RHEL-like systems

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -57,8 +57,8 @@ _start() {
     [ -x $exec ] || exit 5
 
     umask 077
-    touch $pidfile
-    chown $user $pidfile
+    touch $pidfile $logfile
+    chown $user $pidfile $logfile
 
     echo -n $"Starting <%= @name %>: "
     daemon \


### PR DESCRIPTION
Consul daemon fail to start if `consul` user doesn't have write permissions to $logfile
```
# service consul start
Starting consul:                                           [  OK  ]
bash: /var/log/consul.log: Permission denied
```

It was implemented for Debian, but was missing for RHEL-like systems. So, this PR fixes that