### PR TITLE
Prevent "consul" service to be restarted on update

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -87,7 +87,7 @@ module ConsulCookbook
         service.directory(new_resource.data_dir)
         service.user(new_resource.user)
         service.environment(new_resource.environment)
-        service.restart_on_update(true)
+        service.restart_on_update(false)
         service.options(:systemd, template: 'consul:systemd.service.erb')
         service.options(:sysvinit, template: 'consul:sysvinit.service.erb')
 


### PR DESCRIPTION
https://github.com/johnbellone/consul-cookbook/issues/288 was not completely fixed by https://github.com/johnbellone/consul-cookbook/commit/80f4a1ce4edb1638482e2391dabd1ba547ed7fad because poise service option `restart_on_update` is still set to `true`.
It means that consul version update, causing init script re-rendering, will also cause consul service to be restarted. 
This PR prevents this behaviour.

Closes https://github.com/johnbellone/consul-cookbook/issues/307 (as "won't fix")

cc: @johnbellone 