### PR TITLE
consul_installation: Fix binary base url for Linux x86

### DIFF
--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -84,7 +84,7 @@ module ConsulCookbook
       def self.binary_basename(node, resource)
         case node['kernel']['machine']
         when 'x86_64', 'amd64' then ['consul', resource.version, node['os'], 'amd64'].join('_')
-        when 'i386' then ['consul', resource.version, node['os'], '386'].join('_')
+        when /i\d86/ then ['consul', resource.version, node['os'], '386'].join('_')
         else ['consul', resource.version, node['os'], node['kernel']['machine']].join('_')
         end.concat('.zip')
       end


### PR DESCRIPTION
At the moment `consul_installation_binary#binary_basename` returns an invalid base url if `node['kernel']['machine']` is not literally 'i386'.

Reproduced on CentOS 5.11 x86: attribute `node['kernel']['machine']` is "i686" there, so the url became the following:
```
https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_i686.zip
# 403 "Forbidden"
```
However it should be:
```
https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_386.zip
```

This PR fixes that issue.