### PR TITLE
Web UI installation fails when using default recipe

### DIFF
--- a/libraries/consul_installation_webui.rb
+++ b/libraries/consul_installation_webui.rb
@@ -46,6 +46,10 @@ module ConsulCookbook
           directory ::File.join(options[:extract_to], new_resource.version) do
             recursive true
           end
+          
+          directory ::File.dirname(options[:symlink_to]) do
+            recursive true
+          end
 
           zipfile options[:archive_basename] do
             path ::File.join(options[:extract_to], new_resource.version)

--- a/libraries/consul_installation_webui.rb
+++ b/libraries/consul_installation_webui.rb
@@ -46,7 +46,7 @@ module ConsulCookbook
           directory ::File.join(options[:extract_to], new_resource.version) do
             recursive true
           end
-          
+
           directory ::File.dirname(options[:symlink_to]) do
             recursive true
           end

--- a/test/spec/libraries/consul_installation_webui_spec.rb
+++ b/test/spec/libraries/consul_installation_webui_spec.rb
@@ -15,6 +15,12 @@ describe ConsulCookbook::Provider::ConsulInstallationWebui do
         recursive: true
       )
     end
+    
+    it do is_expected.to create_directory('/var/lib/consul')
+      .with(
+        recursive: true
+      )
+    end
 
     it do is_expected.to unzip_zipfile('consul_0.6.4_web_ui.zip')
       .with(


### PR DESCRIPTION
The destination for the web ui symlink `/var/lib/consul` doesn't exist until the `consul_service` resource is created. I've added a directory resource to create it. 