### PR TITLE
Consul Watch: Ignore owner/group on windows machines 

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -111,7 +111,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.owner
               group new_resource.group
               mode '0755'
@@ -120,7 +120,7 @@ module ConsulCookbook
           end
 
           file new_resource.path do
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.owner
               group new_resource.group
               mode '0640'

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -111,7 +111,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.owner
               group new_resource.group
               mode '0755'
@@ -120,7 +120,7 @@ module ConsulCookbook
           end
 
           file new_resource.path do
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.owner
               group new_resource.group
               mode '0640'

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -45,7 +45,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.user
               group new_resource.group
               mode '0755'
@@ -54,7 +54,7 @@ module ConsulCookbook
 
           file new_resource.path do
             content new_resource.to_json
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.user
               group new_resource.group
               mode '0640'

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -45,7 +45,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.user
               group new_resource.group
               mode '0755'
@@ -54,7 +54,7 @@ module ConsulCookbook
 
           file new_resource.path do
             content new_resource.to_json
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.user
               group new_resource.group
               mode '0640'

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -33,7 +33,7 @@ module ConsulCookbook
       # @api private
       def self.default_inversion_options(node, resource)
         archive_basename = binary_basename(node, resource)
-        extract_to = node.windows? ? node.config_prefix_path : '/opt/consul'
+        extract_to = windows? ? node.config_prefix_path : '/opt/consul'
         super.merge(
           version: resource.version,
           archive_url: default_archive_url % { version: resource.version, basename: archive_basename },

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -33,7 +33,7 @@ module ConsulCookbook
       # @api private
       def self.default_inversion_options(node, resource)
         archive_basename = binary_basename(node, resource)
-        extract_to = windows? ? node.config_prefix_path : '/opt/consul'
+        extract_to = node.windows? ? node.config_prefix_path : '/opt/consul'
         super.merge(
           version: resource.version,
           archive_url: default_archive_url % { version: resource.version, basename: archive_basename },

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -55,7 +55,7 @@ module ConsulCookbook
             if node['os'].eql? 'linux'
               owner new_resource.user
               group new_resource.group
-              mode '0755'
+              mode '0640'
             end
           end
         end

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -43,7 +43,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.user
               group new_resource.group
               mode '0755'
@@ -52,7 +52,7 @@ module ConsulCookbook
 
           file new_resource.path do
             content new_resource.to_json
-            if node['os'].eql? 'linux'
+            unless Chef::Platform.windows?
               owner new_resource.user
               group new_resource.group
               mode '0640'

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -43,7 +43,7 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.user
               group new_resource.group
               mode '0755'
@@ -52,7 +52,7 @@ module ConsulCookbook
 
           file new_resource.path do
             content new_resource.to_json
-            unless Chef::Platform.windows?
+            unless windows?
               owner new_resource.user
               group new_resource.group
               mode '0640'

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -43,16 +43,20 @@ module ConsulCookbook
         notifying_block do
           directory ::File.dirname(new_resource.path) do
             recursive true
-            owner new_resource.user
-            group new_resource.group
-            mode '0755'
+            if node['os'].eql? 'linux'
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
           end
 
           file new_resource.path do
-            owner new_resource.user
-            group new_resource.group
             content new_resource.to_json
-            mode '0640'
+            if node['os'].eql? 'linux'
+              owner new_resource.user
+              group new_resource.group
+              mode '0755'
+            end
           end
         end
       end


### PR DESCRIPTION
Same owner/group strategy as in https://github.com/johnbellone/consul-cookbook/blob/master/libraries/consul_definition.rb.