### PR TITLE
Do not install a dedicated web UI by default

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,13 +55,6 @@ config = consul_config service_name do |r|
   notifies :reload, "consul_service[#{service_name}]", :delayed
 end
 
-consul_installation "Consul WebUI: #{node['consul']['version']}" do
-  provider :webui
-  version node['consul']['version']
-  options symlink_to: config.ui_dir if config.ui_dir
-  only_if { config.ui == true }
-end
-
 install = consul_installation node['consul']['version'] do |r|
   if node['consul']['installation']
     node['consul']['installation'].each_pair { |k, v| r.send(k, v) }


### PR DESCRIPTION
Being enabled in [Consul 0.6.1+](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#061-january-6-2016), config option `ui` activates a built-in Web UI, so there is no need to deploy a dedicated instance.

I've mentioned it here: https://github.com/johnbellone/consul-cookbook/pull/298#issuecomment-199859124
