### PR TITLE
More permissions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[consul::default]
+      - recipe[consul_spec::default]
     attributes:
       consul:
         config: &default-config
@@ -49,7 +49,7 @@ suites:
           encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
   - name: git
     run_list:
-      - recipe[consul::default]
+      - recipe[consul_spec::default]
     attributes:
       consul:
         config: *default-config
@@ -59,7 +59,7 @@ suites:
       - windows-2012r2
   - name: webui
     run_list:
-      - recipe[consul::default]
+      - recipe[consul_spec::default]
     attributes:
       consul:
         config:
@@ -70,8 +70,6 @@ suites:
           encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
   - name: acl
     run_list:
-      - recipe[consul::default]
-      - recipe[consul::client_gem]
       - recipe[consul_spec::acl]
     attributes:
       consul:

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: 'consul')
+      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
 
       # @!attribute type
       # @return [String]
@@ -49,6 +49,9 @@ module ConsulCookbook
               owner new_resource.user
               group new_resource.group
               mode '0755'
+              # Prevent clobbering permissions on the directory since the intent
+              # in this context is to set the permissions of the definition file
+              not_if { Dir.exist? self.path }
             end
           end
 

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -51,7 +51,7 @@ module ConsulCookbook
               mode '0755'
               # Prevent clobbering permissions on the directory since the intent
               # in this context is to set the permissions of the definition file
-              not_if { Dir.exist? self.path }
+              not_if { Dir.exist? path }
             end
           end
 

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
+      attribute(:user, kind_of: String, default: 'consul')
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
+      attribute(:group, kind_of: String, default: 'consul')
 
       # @!attribute type
       # @return [String]

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: 'consul')
+      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
 
       # @!attribute type
       # @return [String]

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
+      attribute(:user, kind_of: String, default: 'consul')
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
+      attribute(:group, kind_of: String, default: 'consul')
 
       # @!attribute type
       # @return [String]

--- a/test/cookbooks/consul_spec/recipes/acl.rb
+++ b/test/cookbooks/consul_spec/recipes/acl.rb
@@ -1,3 +1,6 @@
+include_recipe 'consul_spec::default'
+include_recipe 'consul::client_gem'
+
 package 'curl'
 
 consul_acl 'anonymous' do

--- a/test/cookbooks/consul_spec/recipes/consul_definition.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_definition.rb
@@ -1,0 +1,21 @@
+
+# The ruby interpreter is guaranteed to exist since it's currently running.
+file "/consul_definition_check.rb" do
+  content (<<-EOF).gsub(/^ */, '')
+    #!#{RbConfig.ruby}
+    exit 0
+  EOF
+  unless node.platform?('windows')
+    owner 'root'
+    mode '0755'
+  end
+end
+
+consul_definition 'consul_definition_check' do
+  type 'check'
+  parameters(id: "consul_definition_check",
+             script: '/consul_definition_check.rb',
+             interval: '10s',
+             timeout: '10s')
+  notifies :reload, 'consul_service[consul]', :delayed
+end

--- a/test/cookbooks/consul_spec/recipes/consul_definition.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_definition.rb
@@ -13,6 +13,7 @@ end
 
 consul_definition 'consul_definition_check' do
   type 'check'
+  user 'root'
   parameters(id: "consul_definition_check",
              script: '/consul_definition_check.rb',
              interval: '10s',

--- a/test/cookbooks/consul_spec/recipes/consul_watch.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_watch.rb
@@ -13,6 +13,7 @@ end
 
 consul_watch 'consul_watch_check' do
   type 'event'
+  user 'root'
   parameters(handler: "/consul_watch_handler.rb")
   notifies :reload, 'consul_service[consul]', :delayed
 end

--- a/test/cookbooks/consul_spec/recipes/consul_watch.rb
+++ b/test/cookbooks/consul_spec/recipes/consul_watch.rb
@@ -1,0 +1,18 @@
+
+# The ruby interpreter is guaranteed to exist since it's currently running.
+file "/consul_watch_handler.rb" do
+  content (<<-EOF).gsub(/^ */, '')
+    #!#{RbConfig.ruby}
+    exit 0
+  EOF
+  unless node.platform?('windows')
+    owner 'root'
+    mode '0755'
+  end
+end
+
+consul_watch 'consul_watch_check' do
+  type 'event'
+  parameters(handler: "/consul_watch_handler.rb")
+  notifies :reload, 'consul_service[consul]', :delayed
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -89,3 +89,19 @@ end script
     end
   end
 end
+
+describe file("#{confd_dir}/consul_definition_check.json") do
+  it { should be_file }
+  it { should be_owned_by     'root' }
+  it { should be_grouped_into 'consul' }
+
+  it { should be_mode 640 }
+end
+
+describe file("#{confd_dir}/consul_watch_check.json") do
+  it { should be_file }
+  it { should be_owned_by     'root' }
+  it { should be_grouped_into 'consul' }
+
+  it { should be_mode 640 }
+end

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -8,11 +8,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     default_attributes['consul'] = {
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
-        },
-      'config' => {
-        'owner' => 'root',
-        'group' => 'consul'
-       }
+        }
       }
   end
 
@@ -20,6 +16,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     recipe do
       consul_definition 'redis' do
         type 'service'
+        user 'root'
         parameters(tags: %w{master}, address: '127.0.0.1', port: 6379, interval: '10s')
       end
     end
@@ -44,6 +41,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     recipe do
       consul_definition 'redis' do
         type 'service'
+        user 'root'
         parameters(name: 'myredis', tags: %w{master}, address: '127.0.0.1', port: 6379, interval: '10s')
       end
     end
@@ -68,6 +66,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     recipe do
       consul_definition 'web-api' do
         type 'check'
+        user 'root'
         parameters(http: 'http://localhost:5000/health', ttl: '30s')
       end
     end

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -8,7 +8,11 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     default_attributes['consul'] = {
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
-        }
+        },
+      'config' => {
+        'owner' => 'root',
+        'group' => 'consul'
+       }
       }
   end
 
@@ -23,7 +27,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
-      .with(user: 'consul', group: 'consul', mode: '0640')
+      .with(user: 'root', group: 'consul', mode: '0640')
       .with(content: JSON.pretty_generate(
         service: {
           tags: ['master'],
@@ -47,7 +51,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
-      .with(user: 'consul', group: 'consul', mode: '0640')
+      .with(user: 'root', group: 'consul', mode: '0640')
       .with(content: JSON.pretty_generate(
         service: {
           name: 'myredis',
@@ -71,7 +75,7 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/web-api.json')
-      .with(user: 'consul', group: 'consul', mode: '0640')
+      .with(user: 'root', group: 'consul', mode: '0640')
       .with(content: JSON.pretty_generate(
         check: {
           http: 'http://localhost:5000/health',

--- a/test/spec/libraries/consul_watch_spec.rb
+++ b/test/spec/libraries/consul_watch_spec.rb
@@ -8,7 +8,11 @@ describe ConsulCookbook::Resource::ConsulWatch do
     default_attributes['consul'] = {
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
-        }
+        },
+      'config' => {
+        'owner' => 'root',
+        'group' => 'consul'
+       }
       }
   end
 
@@ -23,7 +27,7 @@ describe ConsulCookbook::Resource::ConsulWatch do
     it { is_expected.to create_directory('/etc/consul/conf.d') }
     it do
       is_expected.to create_file('/etc/consul/conf.d/foo.json')
-      .with(user: 'consul', group: 'consul', mode: '0640')
+      .with(user: 'root', group: 'consul', mode: '0640')
       .with(content: JSON.pretty_generate(
         {
           watches: [

--- a/test/spec/libraries/consul_watch_spec.rb
+++ b/test/spec/libraries/consul_watch_spec.rb
@@ -8,11 +8,7 @@ describe ConsulCookbook::Resource::ConsulWatch do
     default_attributes['consul'] = {
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
-        },
-      'config' => {
-        'owner' => 'root',
-        'group' => 'consul'
-       }
+        }
       }
   end
 
@@ -20,6 +16,7 @@ describe ConsulCookbook::Resource::ConsulWatch do
     recipe do
       consul_watch 'foo' do
         type 'key'
+        user 'root'
         parameters(key: 'foo/bar/baz', handler: '/bin/false')
       end
     end


### PR DESCRIPTION
This includes the branch from #323 but goes a step further and uses the configured attributes as defaults for the `consul_definition` and `consul_watch` resources. I made this a separate pull request since it wasn't something we discussed in #322.