### PR TITLE
Misc bugfixes

### DIFF
--- a/libraries/consul_execute.rb
+++ b/libraries/consul_execute.rb
@@ -16,7 +16,7 @@ module ConsulCookbook
       default_action(:run)
 
       attribute(:command, kind_of: String, name_attribute: true)
-      attribute(:environment, kind_of: String, default: { 'PATH' => '/usr/local/bin:/usr/bin:/bin' })
+      attribute(:environment, kind_of: Hash, default: { 'PATH' => '/usr/local/bin:/usr/bin:/bin' })
       attribute(:options, option_collector: true, default: {})
 
       action(:run) do

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -38,7 +38,7 @@ module ConsulCookbook
       attribute(:data_dir, kind_of: String, default: lazy { node['consul']['config']['data_dir'] })
       # @!attribute config_dir
       # @return [String]
-      attribute(:config_dir, kind_of: String, default: lazy { node['consul']['config']['config_dir'] })
+      attribute(:config_dir, kind_of: String, default: lazy { node['consul']['service']['config_dir'] })
       # @!attribute nssm_params
       # @return [String]
       attribute(:nssm_params, kind_of: Hash, default: lazy { node['consul']['service']['nssm_params'] })

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -64,7 +64,7 @@ _start() {
     daemon \
          --pidfile=$pidfile \
          --user=$user \
-         " { $exec <%= @daemon_options %> > $logfile 2>&1 & } ; echo \$! >| $pidfile "
+         " { $exec <%= @daemon_options %> >> $logfile 2>&1 & } ; echo \$! >| $pidfile "
      RETVAL=$?
      echo
      [ $RETVAL -eq 0 ] && touch $lockfile

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -64,7 +64,7 @@ _start() {
     daemon \
          --pidfile=$pidfile \
          --user=$user \
-         " { $exec <%= @daemon_options %> &>> $logfile & } ; echo \$! >| $pidfile "
+         " { $exec <%= @daemon_options %> > $logfile 2>&1 & } ; echo \$! >| $pidfile "
      RETVAL=$?
      echo
      [ $RETVAL -eq 0 ] && touch $lockfile

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -6,3 +6,12 @@ else
   set :backend, :cmd
   set :os, family: 'windows'
 end
+
+# Tells serverspec to use a login shell for running chkconfig/service,
+# which prevents false error reports on Centos 5.
+begin
+  if File.read("/etc/redhat-release") =~ /release 5\./
+    Specinfra.configuration.login_shell = true
+  end
+rescue SystemCallError
+end


### PR DESCRIPTION
Two bugfixes:
1. This quells a warning about "Option environment must be a kind of [String]" that gets emitted during rspec runs. Chef 13 will not allow the type mismatch.
2. The consul_service resource was using a default value attribute that was not configured anywhere. This changes it to use the same default as consul_config.