### PR TITLE
Use nologin for service user

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ unless windows?
   end
 
   user node['consul']['service_user'] do
-    shell '/bin/bash'
+    shell '/sbin/nologin'
     group node['consul']['service_group']
     system true
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,6 +42,7 @@ unless windows?
     shell '/sbin/nologin'
     group node['consul']['service_group']
     system true
+    not_if { node['consul']['service_user'] == 'root' }
   end
 end
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -15,7 +15,11 @@ end
 describe user('consul') do
   it { should exist }
   it { should belong_to_group('consul') }
-  it { should have_login_shell('/bin/bash') }
+end
+
+describe command("su - consul -c 'echo successfully logged in'") do
+  its(:stdout)      { should_not match /successfully logged in/ }
+  its(:exit_status) { should_not eq 0 }
 end
 
 describe service('consul') do

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "consul::default" do
+
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  context "with default service_user" do
+    it 'creates the user without a login shell' do
+      expect(chef_run).to create_user('consul').with(shell: '/sbin/nologin')
+    end
+  end
+
+  context "with root service_user" do
+    before do
+      default_attributes['consul'] ||= {}
+      default_attributes['consul']['service_user'] = 'root'
+    end
+
+    it 'does not try to create the root user' do
+      expect(chef_run).to_not create_user('root')
+    end
+  end
+end


### PR DESCRIPTION
Since the service user shouldn't be logging in with an interactive shell, set the shell to /sbin/nologin.