### PR TITLE
Use correct nologin for distro

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ unless windows?
   end
 
   user node['consul']['service_user'] do
-    shell '/sbin/nologin'
+    shell %w( /sbin/nologin /usr/sbin/nologin /bin/false ).select { |f| ::File.exist?(f) }.first
     group node['consul']['service_group']
     system true
     not_if { node['consul']['service_user'] == 'root' }

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -15,6 +15,7 @@ end
 describe user('consul') do
   it { should exist }
   it { should belong_to_group('consul') }
+  it { should have_login_shell(['debian', 'ubuntu'].include?(os[:family]) ? "/usr/sbin/nologin" : "/sbin/nologin")}
 end
 
 describe command("su - consul -c 'echo successfully logged in'") do


### PR DESCRIPTION
This fixes the nologin shell on debian-based systems since they use /usr/sbin instead of /sbin for this. The existing code behaves as expected (meaning it doesn't allow login) but the passwd entry points at a nonexistent file.