### PR TITLE
missing do in while loop upstart.service.erb line 51

### DIFF
--- a/templates/default/upstart.service.erb
+++ b/templates/default/upstart.service.erb
@@ -48,5 +48,5 @@ pre-stop script
 end script
 <%- end -%>
 post-start script
-  while ! <%= @options[:executable] %> info ; sleep 1; done
+  while ! <%= @options[:executable] %> info ; do sleep 1; done
 end script


### PR DESCRIPTION
The new upstart template works great in my testing.  It solved an issue I was running into with consul not coming up at boot.  I noticed however that there was a "do" missing in the post-start while loop.  