### PR TITLE
Start consul service on runlevel 2 in sysvinit

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -9,8 +9,8 @@
 # Provides:       <%= @name %>
 # Required-Start: $local_fs $network
 # Required-Stop:  $local_fs $network
-# Default-Start: 3 4 5
-# Default-Stop:  0 1 2 6
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
 # Short-Description: Manage the consul agent
 ### END INIT INFO
 


### PR DESCRIPTION
Current LSB header of sysvinit script defines consul service to start on runlevel 3.

Default runlevel in Debian is 2 - https://wiki.debian.org/RunLevel, so it mean that when Debian based host is restarted, then consul service is not started.

To fix this issue I have update LSB header in sysvinit script so now consul service will be launched on runlevel 2.