### PR TITLE
Allow specification of shell for the consul user

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,13 +33,15 @@ if node['firewall']['allow_consul']
   end
 end
 
+service_name = node['consul']['service_name']
 poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
+  shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?
   not_if { windows? }
   not_if { node['consul']['service_user'] == 'root' }
+  notifies :restart, "consul_service[#{service_name}]", :delayed
 end
 
-service_name = node['consul']['service_name']
 config = consul_config service_name do |r|
   node['consul']['config'].each_pair { |k, v| r.send(k, v) }
   notifies :reload, "consul_service[#{service_name}]", :delayed


### PR DESCRIPTION
Hi,

following two commits are changing shell of the consul user to /bin/nologin (or its variations)
- [Use nologin for service user](https://github.com/johnbellone/consul-cookbook/commit/938357ac844e0b6df66d92142957cfa6a20393a0)
- [Modify user/group creation to use poise-service-user](https://github.com/johnbellone/consul-cookbook/commit/68bc28a57add628476e05851db6412f1cbd72361)

this configuration prevents consul from executing handler in [consul watch](https://www.consul.io/docs/agent/watches.html) with following error:

```
2016/09/20 21:33:02 [ERR] agent: Failed to invoke watch handler 'XYZ': exit status 1
```

This patch allows wrapper cookbook to specify shell explicitly while retaining "security" for people not using consul watch functionality.
