### PR TITLE
Fix installation on arm machines

### DIFF
--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -86,6 +86,7 @@ module ConsulCookbook
         case node['kernel']['machine']
         when 'x86_64', 'amd64' then ['consul', resource.version, node['os'], 'amd64'].join('_')
         when /i\d86/ then ['consul', resource.version, node['os'], '386'].join('_')
+        when /^arm/ then ['consul', resource.version, node['os'], 'arm'].join('_')
         else ['consul', resource.version, node['os'], node['kernel']['machine']].join('_')
         end.concat('.zip')
       end


### PR DESCRIPTION
There is no `armv7l` package only a `arm` package, therefore this throws an error.