### PR TITLE
WIP: Fix "webui" installation with poise_archive

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'poise', '~> 2.2'
+gem 'poise-archive'
 gem 'poise-service', '~> 1.0'
 gem 'poise-boiler'
 gem 'chef-sugar'

--- a/test/spec/libraries/consul_installation_webui_spec.rb
+++ b/test/spec/libraries/consul_installation_webui_spec.rb
@@ -28,11 +28,10 @@ describe ConsulCookbook::Provider::ConsulInstallationWebui do
       )
     end
 
-    it do is_expected.to unzip_zipfile('consul_0.7.0_web_ui.zip')
+    it do is_expected.to unpack_poise_archive('https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip')
       .with(
         checksum: '42212089c228a73a0881a5835079c8df58a4f31b5060a3b4ffd4c2497abe3aa8',
-        path: '/opt/consul-webui/0.7.0',
-        source: 'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip'
+        extract_to: '/opt/consul-webui'
       )
     end
   end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'chefspec'
 require 'chefspec/policyfile'
+require 'poise_archive'
 require 'poise_boiler/spec_helper'
 require_relative '../../libraries/helpers'
 


### PR DESCRIPTION
Work in progress: I try to make unit test passing, but seems like they are still failing.
Any suggestions are welcome.

@johnbellone @Ginja What do you think - is it still reasonable to support `:webui` provider for `consul_installation` resource if there is a builtin webui in Consul 0.6.1+ ?
FYI: the current implementation of `:webui` provider is also incompatible with Windows.
