### PR TITLE
Remove default value for `ui_dir`

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -97,7 +97,7 @@ module ConsulCookbook
       attribute(:translate_wan_addrs, equal_to: [true, false], default: false)
       attribute(:udp_answer_limit, kind_of: Integer, default: 3)
       attribute(:ui, equal_to: [true, false], default: false)
-      attribute(:ui_dir, kind_of: String, default: '/var/lib/consul/ui')
+      attribute(:ui_dir, kind_of: String)
       attribute(:unix_sockets, kind_of: [Hash, Mash])
       attribute(:verify_incoming, equal_to: [true, false], default: false)
       attribute(:verify_outgoing, equal_to: [true, false], default: false)


### PR DESCRIPTION
Needs to be unset for the `ui` flag to work as expected.  The `ui_dir`
flag overrides the embedded web UI.  If set, and the web UI is not
available at the specified path, the server will return 404s.

A default value in the resource means that even if the node attribute is
explicitly rm'd, the config value will still be populated.

Fixes #339, refs #315
