### PR TITLE
Allow disabling create_service_user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@
 default['consul']['service_name'] = 'consul'
 default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
+default['consul']['create_service_user'] = true
 
 default['consul']['config']['owner'] = 'consul'
 default['consul']['config']['group'] = 'consul'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,7 @@ poise_service_user node['consul']['service_user'] do
   shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?
   not_if { windows? }
   not_if { node['consul']['service_user'] == 'root' }
+  not_if { node['consul']['create_service_user'] == false }
   notifies :restart, "consul_service[#{service_name}]", :delayed
 end
 

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -20,4 +20,15 @@ describe "consul::default" do
       expect(chef_run).to_not create_poise_service_user('root')
     end
   end
+
+  context "with create_service_user disabled" do
+    before do
+      default_attributes['consul'] ||= {}
+      default_attributes['consul']['create_service_user'] = false
+    end
+
+    it 'does not try to create the user' do
+      expect(chef_run).to_not create_poise_service_user('consul')
+    end
+  end
 end


### PR DESCRIPTION
Users may wish to manage the `service_user` externally, this change adds
an attribute `create_service_user` that defaults to `true`.  If set to
`false`, disables the creation of the `service_user` by this cookbook.

Examples use-cases may be LDAP/NIS users or custom user attributes
managed by an alternative cookbook.
