### PR TITLE
Use config user/group for consul_definition instead of hard coded string

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -20,10 +20,10 @@ module ConsulCookbook
       attribute(:path, kind_of: String, name_attribute: true)
       # @!attribute owner
       # @return [String]
-      attribute(:owner, kind_of: String, default: 'consul')
+      attribute(:owner, kind_of: String, default: lazy { node['consul']['service_user'] })
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['service_group'] })
       # @!attribute config_dir
       # @return [String]
       attribute(:config_dir, kind_of: String, default: lazy { node['consul']['service']['config_dir'] })

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: 'consul')
+      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
 
       # @!attribute type
       # @return [String]

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['consul']['config']['owner'] })
+      attribute(:user, kind_of: String, default: lazy { node['consul']['service_user'] })
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['consul']['config']['group'] })
+      attribute(:group, kind_of: String, default: lazy { node['consul']['service_group'] })
 
       # @!attribute type
       # @return [String]

--- a/test/spec/libraries/consul_config_spec.rb
+++ b/test/spec/libraries/consul_config_spec.rb
@@ -9,6 +9,8 @@ describe ConsulCookbook::Resource::ConsulConfig do
     recipe = double('Chef::Recipe')
     allow_any_instance_of(Chef::RunContext).to receive(:include_recipe).and_return([recipe])
     default_attributes['consul'] = {
+      'service_user' => 'consul',
+      'service_group' => 'consul',
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
        }

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -6,6 +6,10 @@ describe ConsulCookbook::Resource::ConsulDefinition do
   let(:chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
   before do
     default_attributes['consul'] = {
+      'config' => {
+        'owner' => 'consul',
+        'group' => 'consul'
+      },
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
         }
@@ -50,6 +54,42 @@ describe ConsulCookbook::Resource::ConsulDefinition do
     it do
       is_expected.to create_file('/etc/consul/conf.d/redis.json')
       .with(user: 'root', group: 'consul', mode: '0640')
+      .with(content: JSON.pretty_generate(
+        service: {
+          name: 'myredis',
+          tags: ['master'],
+          address: '127.0.0.1',
+          port: 6379,
+          interval: '10s'
+        }
+      ))
+    end
+  end
+
+  context 'service definition with owner and group from node config' do
+    before do
+      default_attributes['consul'] = {
+        'config' => {
+          'owner' => 'root',
+          'group' => 'root'
+        },
+        'service' => {
+          'config_dir' => '/etc/consul/conf.d'
+          }
+        }
+    end
+
+    recipe do
+      consul_definition 'redis' do
+        type 'service'
+        parameters(name: 'myredis', tags: %w{master}, address: '127.0.0.1', port: 6379, interval: '10s')
+      end
+    end
+
+    it { is_expected.to create_directory('/etc/consul/conf.d') }
+    it do
+      is_expected.to create_file('/etc/consul/conf.d/redis.json')
+      .with(user: 'root', group: 'root', mode: '0640')
       .with(content: JSON.pretty_generate(
         service: {
           name: 'myredis',

--- a/test/spec/libraries/consul_definition_spec.rb
+++ b/test/spec/libraries/consul_definition_spec.rb
@@ -6,10 +6,8 @@ describe ConsulCookbook::Resource::ConsulDefinition do
   let(:chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
   before do
     default_attributes['consul'] = {
-      'config' => {
-        'owner' => 'consul',
-        'group' => 'consul'
-      },
+      'service_user' => 'consul',
+      'service_group' => 'consul',
       'service' => {
         'config_dir' => '/etc/consul/conf.d'
         }
@@ -69,10 +67,8 @@ describe ConsulCookbook::Resource::ConsulDefinition do
   context 'service definition with owner and group from node config' do
     before do
       default_attributes['consul'] = {
-        'config' => {
-          'owner' => 'root',
-          'group' => 'root'
-        },
+        'service_user' => 'root',
+        'service_group' => 'root',
         'service' => {
           'config_dir' => '/etc/consul/conf.d'
           }


### PR DESCRIPTION
Does anything speak against using the `node['consul']['config']['group']` and `node['consul']['config']['user']` value for the default consul_definition attributes?
