### PR TITLE
Fixed service user specs

### DIFF
--- a/test/spec/libraries/consul_installation_webui_spec.rb
+++ b/test/spec/libraries/consul_installation_webui_spec.rb
@@ -8,30 +8,32 @@ describe ConsulCookbook::Provider::ConsulInstallationWebui do
   let(:chefspec_options) { {platform: 'ubuntu', version: '14.04'} }
 
   context 'webui installation' do
-    pending('replace with poise-archive')
-
     recipe do
       consul_installation '0.7.0' do
         provider :webui
       end
     end
 
-    it do is_expected.to create_directory('/opt/consul-webui/0.7.0')
+    it do
+      pending('replace with poise-archive')
+      is_expected.to create_directory('/opt/consul-webui/0.7.0')
       .with(
         recursive: true
       )
     end
 
-    it do is_expected.to create_directory('/var/lib/consul')
+    it do
+      pending('replace with poise-archive')
+      is_expected.to create_directory('/var/lib/consul')
       .with(
         recursive: true
       )
     end
 
-    it do is_expected.to unzip_zipfile('consul_0.7.0_web_ui.zip')
+    it do
+      pending('replace with poise-archive')
+      is_expected.to unzip_zipfile('consul_0.7.0_web_ui.zip')
       .with(
-        checksum: '42212089c228a73a0881a5835079c8df58a4f31b5060a3b4ffd4c2497abe3aa8',
-        path: '/opt/consul-webui/0.7.0',
         source: 'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_web_ui.zip'
       )
     end

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe "consul::default" do
-
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:service_user)        { }
+  let(:create_service_user) { true }
+  let(:platform)            { { :platform => 'ubuntu', :version => '14.04' } }
+  
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform) do |node|
+      node.normal['consul']['service_user']        = service_user
+      node.normal['consul']['create_service_user'] = create_service_user
+    end
+    runner.converge(described_recipe)
+  end
 
   context "with default service_user" do
     it 'creates the user without a login shell' do
@@ -11,10 +20,7 @@ describe "consul::default" do
   end
 
   context "with johnny5 service_user" do
-    before do
-      default_attributes['consul'] ||= {}
-      default_attributes['consul']['service_user'] = 'johnny5'
-    end
+    let(:service_user) { 'johnny5' }
 
     it 'creates the requested user' do
       expect(chef_run).to create_poise_service_user('johnny5')
@@ -25,10 +31,7 @@ describe "consul::default" do
   end
 
   context "with root service_user" do
-    before do
-      default_attributes['consul'] ||= {}
-      default_attributes['consul']['service_user'] = 'root'
-    end
+    let(:service_user) { 'root' }
 
     it 'does not try to create the root user' do
       expect(chef_run).to_not create_poise_service_user('root')
@@ -39,11 +42,16 @@ describe "consul::default" do
   end
 
   context "with create_service_user disabled" do
-    before do
-      default_attributes['consul'] ||= {}
-      default_attributes['consul']['create_service_user'] = false
-    end
+    let(:create_service_user) { false }
 
+    it 'does not try to create the user' do
+      expect(chef_run).to_not create_poise_service_user('consul')
+    end
+  end
+  
+  context 'on Windows' do
+    let(:platform) { { :platform => 'windows', :version => '2012r2' } }
+    
     it 'does not try to create the user' do
       expect(chef_run).to_not create_poise_service_user('consul')
     end

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -10,6 +10,20 @@ describe "consul::default" do
     end
   end
 
+  context "with johnny5 service_user" do
+    before do
+      default_attributes['consul'] ||= {}
+      default_attributes['consul']['service_user'] = 'johnny5'
+    end
+
+    it 'creates the requested user' do
+      expect(chef_run).to create_poise_service_user('johnny5')
+    end
+    it 'does not try to create the default user' do
+      expect(chef_run).to_not create_poise_service_user('consul')
+    end
+  end
+
   context "with root service_user" do
     before do
       default_attributes['consul'] ||= {}
@@ -18,6 +32,9 @@ describe "consul::default" do
 
     it 'does not try to create the root user' do
       expect(chef_run).to_not create_poise_service_user('root')
+    end
+    it 'does not try to create the default user' do
+      expect(chef_run).to_not create_poise_service_user('consul')
     end
   end
 

--- a/test/spec/recipes/default_spec.rb
+++ b/test/spec/recipes/default_spec.rb
@@ -50,7 +50,7 @@ describe "consul::default" do
   end
   
   context 'on Windows' do
-    let(:platform) { { :platform => 'windows', :version => '2012r2' } }
+    let(:platform) { { :platform => 'windows', :version => '2012R2' } }
     
     it 'does not try to create the user' do
       expect(chef_run).to_not create_poise_service_user('consul')


### PR DESCRIPTION
Added tests for service user creation to ensure that default user is not created and verify that nothing is created for Windows.

Sets individual web_ui specs to pending, so that they are ignored.

Closes johnbellone#365