### PR TITLE
[config] add dogstatsd_addr configuration attribute

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -90,6 +90,7 @@ module ConsulCookbook
       attribute(:start_join, kind_of: Array)
       attribute(:start_join_wan, kind_of: Array)
       attribute(:statsd_addr, kind_of: String)
+      attribute(:dogstatsd_addr, kind_of: String)
       attribute(:statsite_addr, kind_of: String)
       attribute(:statsite_prefix, kind_of: String)
       attribute(:telemetry, kind_of: [Hash, Mash])
@@ -107,7 +108,7 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_replication_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_compression disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name performance ports protocol reconnect_timeout reconnect_timeout_wan recursor recursor_timeout recursors retry_interval retry_interval_wan retry_join retry_join_wan rejoin_after_leave server server_name session_ttl_min skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr statsite_prefix telemetry syslog_facility translate_wan_addrs udp_answer_limit ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches dev_mode unix_sockets}
+        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_replication_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr bootstrap bootstrap_expect check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_compression disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name performance ports protocol reconnect_timeout reconnect_timeout_wan recursor recursor_timeout recursors retry_interval retry_interval_wan retry_join retry_join_wan rejoin_after_leave server server_name session_ttl_min skip_leave_on_interrupt start_join start_join_wan statsd_addr dogstatsd_addr statsite_addr statsite_prefix telemetry syslog_facility translate_wan_addrs udp_answer_limit ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches dev_mode unix_sockets}
         for_keeps << %i{ca_file cert_file key_file} if tls?
         for_keeps = for_keeps.flatten
 


### PR DESCRIPTION
Consul can send metrics to the Datadog Agent using DogStatsD metrics.
This adds support for configuring Consul to use `dogstatsd` metrics with
the cookbook.