### PR TITLE
Add "rb-readline" to Gemfile, fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
     env:  FOODCRITIC=1
   - script:
       - bundle install
-      - /opt/chefdk/embedded/bin/rspec --color --default-path test/spec
+      - bundle exec rspec --color --default-path test/spec
     env:  CHEFSPEC=1
 notifications:
   slack: bloomberg-rnd:BvYmxrV9xj902XWTRNrkLNkR

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :unit, :integration do
   gem 'chefspec'
   gem 'rubyzip'
   gem 'serverspec'
+  gem 'rb-readline'
 end
 
 group :development do


### PR DESCRIPTION
This PR should fix the constant failure of ChefSpec job in our TravisCI builds (including other open PRs). 

I thought that it was an issue of ChefDK, but Chef folks have explained what are we doing wrong:
https://github.com/chef/chef-dk/issues/1097#issuecomment-265217298

@johnbellone, please review this PR.