### PR TITLE
Update Rakefile and TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
----
 sudo: required
 dist: trusty
-language: generic
-cache: bundler
+
+# install the pre-release chef-dk.  Use chef-stable-trusty to install the stable release
 addons:
   apt:
     sources:
       - chef-current-trusty
     packages:
       - chefdk
+
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
+
 services: docker
+
 env:
   matrix:
     - INSTANCE=default-centos-7
@@ -27,25 +31,25 @@ before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-dokken
-  - /opt/chefdk/embedded/bin/chef gem install kitchen-verifier-serverspec
-  - /opt/chefdk/embedded/bin/chef --version
-  - /opt/chefdk/embedded/bin/cookstyle --version
-  - /opt/chefdk/embedded/bin/foodcritic --version
+
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
+
 after_script:
   - docker images
   - docker ps -a
   - cat .kitchen/logs/kitchen.log
+
 matrix:
   include:
-  - script: /opt/chefdk/embedded/bin/cookstyle
-    env:  COOKSTYLE=1
-  - script: /opt/chefdk/embedded/bin/foodcritic . --exclude spec -f any
-    env:  FOODCRITIC=1
-  - script:
+    - before_script:
+      - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+      - /opt/chefdk/embedded/bin/chef --version
+      - /opt/chefdk/embedded/bin/cookstyle --version
+      - /opt/chefdk/embedded/bin/foodcritic --version
+    - script:
       - bundle install
-      - bundle exec rspec --color --default-path test/spec
-    env:  CHEFSPEC=1
+      - bundle exec rake
+      env: UNIT_AND_LINT=1
+
 notifications:
   slack: bloomberg-rnd:BvYmxrV9xj902XWTRNrkLNkR

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@ gem 'poise-boiler'
 gem 'chef-sugar'
 
 group :lint do
-  gem 'cookstyle'
+  gem 'cookstyle', '~> 1.0'
   gem 'rubocop'
   gem 'foodcritic'
 end
 
 group :unit, :integration do
-  gem 'chef-dk'
+  gem 'chef-dk', '~> 1.0'
   gem 'chefspec'
   gem 'rubyzip'
   gem 'serverspec'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['consul']['config']['ports'] = {
   'rpc'      => 8400,
   'serf_lan' => 8301,
   'serf_wan' => 8302,
-  'server'   => 8300
+  'server'   => 8300,
 }
 
 default['consul']['diplomat_version'] = nil
@@ -41,5 +41,5 @@ default['consul']['service']['nssm_params'] = {
   'AppStderr'        => join_path(config_prefix_path, 'error.log'),
   'AppRotateFiles'   => 1,
   'AppRotateOnline'  => 1,
-  'AppRotateBytes'   => 20_000_000
+  'AppRotateBytes'   => 20_000_000,
 }

--- a/libraries/consul_installation_webui.rb
+++ b/libraries/consul_installation_webui.rb
@@ -39,7 +39,7 @@ module ConsulCookbook
       def action_create
         archive_url = options[:archive_url] % {
           version: options[:version],
-          basename: options[:archive_basename]
+          basename: options[:archive_basename],
         }
 
         notifying_block do

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -54,7 +54,7 @@ module ConsulCookbook
       def default_environment
         {
           'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
-          'PATH' => '/usr/local/bin:/usr/bin:/bin'
+          'PATH' => '/usr/local/bin:/usr/bin:/bin',
         }
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -123,7 +123,7 @@ module ConsulCookbook
       # 1 is command not found
       # 3 is service not found
       exit_code = shell_out!(%{"#{nssm_exe}" status consul}, returns: [0, 1, 3]).exitstatus
-      exit_code == 0 ? true : false
+      exit_code.zero?
     end
 
     def nssm_service_status?(expected_status)


### PR DESCRIPTION
This is yet another try to fix TravisCI builds, which have been failed recently because of the new `cookstyle` release v 1.0.1.

This PR fixes current failures and updates `Rakefile` & `.travis.yml`. General purposes:
- Reduce the build time by skipping an initial `bundle install`
- Use a single Travis job to run unit tests, cookbook style checks and foodcritic validation.

I've used examples from the following cookbooks by Chef Inc.:
- https://github.com/chef-cookbooks/chef_nginx
- https://github.com/chef-cookbooks/mysql
