### PR TITLE
Enable passwordless sudo for tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,7 +49,7 @@ suites:
           encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
   - name: client
     provisioner:
-      policyfile: test/fixtures/policies/client.rb
+      policyfile: test/fixtures/policies/default.rb
     attributes:
       consul:
         config:
@@ -78,7 +78,7 @@ suites:
           encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
   - name: acl
     provisioner:
-      policyfile: test/fixtures/policies/acl.rb
+      policyfile: test/fixtures/policies/default.rb
     attributes:
       consul:
         config:

--- a/test/fixtures/policies/_base.rb
+++ b/test/fixtures/policies/_base.rb
@@ -1,8 +1,0 @@
-default_source :community
-default_source :chef_repo, '..'
-cookbook 'consul', path: '../../..'
-run_list 'consul::default', "consul_spec::#{name}"
-named_run_list :centos, 'yum::default', 'yum-centos::default', 'sudo::default', run_list
-named_run_list :debian, 'apt::default', run_list
-named_run_list :freebsd, 'freebsd::default', 'sudo::default', run_list
-named_run_list :windows, 'windows::default', run_list

--- a/test/fixtures/policies/acl.rb
+++ b/test/fixtures/policies/acl.rb
@@ -1,2 +1,0 @@
-name 'acl'
-instance_eval(IO.read(File.expand_path('../_base.rb', __FILE__)))

--- a/test/fixtures/policies/client.rb
+++ b/test/fixtures/policies/client.rb
@@ -1,2 +1,0 @@
-name 'client'
-instance_eval(IO.read(File.expand_path('../_base.rb', __FILE__)))

--- a/test/fixtures/policies/default.rb
+++ b/test/fixtures/policies/default.rb
@@ -1,2 +1,9 @@
 name 'default'
-instance_eval(IO.read(File.expand_path('../_base.rb', __FILE__)))
+default_source :community
+default_source :chef_repo, '..'
+cookbook 'consul', path: '../../..'
+run_list 'consul::default', "consul_spec::#{name}"
+named_run_list :centos, 'yum::default', 'yum-centos::default', 'sudo::default', run_list
+named_run_list :debian, 'apt::default', run_list
+named_run_list :freebsd, 'freebsd::default', 'sudo::default', run_list
+named_run_list :windows, 'windows::default', run_list

--- a/test/fixtures/policies/default.rb
+++ b/test/fixtures/policies/default.rb
@@ -1,9 +1,12 @@
 name 'default'
-default_source :community
+default_source :supermarket
 default_source :chef_repo, '..'
 cookbook 'consul', path: '../../..'
 run_list 'consul::default', "consul_spec::#{name}"
-named_run_list :centos, 'yum::default', 'yum-centos::default', 'sudo::default', run_list
+named_run_list :centos, 'sudo::default', run_list
 named_run_list :debian, 'apt::default', run_list
 named_run_list :freebsd, 'freebsd::default', 'sudo::default', run_list
 named_run_list :windows, 'windows::default', run_list
+
+default['authorization']['sudo']['users'] = %w(kitchen vagrant)
+default['authorization']['sudo']['passwordless'] = true


### PR DESCRIPTION
This PR introduces the similar changes like we did in Vault cookbook: 
https://github.com/legal90/vault-cookbook/commit/f4edbada8b16abc0165a0292a6466e52e93dc726
https://github.com/johnbellone/vault-cookbook/pull/80