### PR TITLE
Remove redundant cookbook dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,6 @@ supports 'arch'
 supports 'windows'
 
 depends 'build-essential'
-depends 'chef-sugar'
 depends 'nssm'
 depends 'golang'
 depends 'firewall', '~> 2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,7 +25,6 @@ depends 'firewall', '~> 2.0'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'
 depends 'poise-service', '~> 1.4'
-depends 'yum-epel'
 
 source_url 'https://github.com/johnbellone/consul-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/johnbellone/consul-cookbook/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,10 +6,6 @@
 #
 include_recipe 'chef-sugar::default'
 
-if rhel?
-  include_recipe 'yum-epel::default' if node['platform_version'].to_i == 5
-end
-
 node.default['nssm']['install_location'] = '%WINDIR%'
 
 if node['firewall']['allow_consul']


### PR DESCRIPTION
- `yum-epel` - It looks unnecessary. Everything should work fine without it. 
- `chef-sugar` - we don't use its helpers anymore.

Let's take a look at the TravisCI build results...