### PR TITLE
Avoid double testing in Travis

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -99,14 +99,6 @@ suites:
           server: true
           datacenter: FortMeade
           encrypt: CGXC2NsXW4AvuB4h5ODYzQ==
-  - name: archive
-    provisioner:
-      policyfile: test/fixtures/policies/default.rb
-    attributes:
-      consul:
-        provider: binary
-        options:
-          version: 0.7.1
   - name: webui
     provisioner:
       policyfile: test/fixtures/policies/default.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ env:
     - INSTANCE=default-ubuntu-1204
     - INSTANCE=default-debian-8
     - INSTANCE=default-debian-7
-    - INSTANCE=archive-centos-7
-    - INSTANCE=archive-centos-6
-    - INSTANCE=archive-ubuntu-1604
-    - INSTANCE=archive-ubuntu-1404
+
 before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ before_script:
   # https://github.com/zuazo/kitchen-in-travis-native/issues/1#issuecomment-142230889
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 
@@ -41,11 +44,6 @@ after_script:
 
 matrix:
   include:
-    - before_script:
-      - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-      - /opt/chefdk/embedded/bin/chef --version
-      - /opt/chefdk/embedded/bin/cookstyle --version
-      - /opt/chefdk/embedded/bin/foodcritic --version
     - script:
       - bundle install
       - bundle exec rake


### PR DESCRIPTION
Currently, the last job for integration test runs twice because of double "before_script" definition.
Relevant PR from mysql cookbook: chef-cookbooks/mysql#500

Also, there is a redundant "archive" suite defined in `.kitchen.dokken.yml`. The provider "binary" is used by default, so there is no difference with the "default" suite here.