### PR TITLE
Remove dead code

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,7 +49,6 @@ install = consul_installation node['consul']['version'] do |r|
 end
 
 consul_service service_name do |r|
-  version node['consul']['version']
   config_file config.path
   program install.consul_program
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,6 @@
 #
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
-include_recipe 'chef-sugar::default'
-
 node.default['nssm']['install_location'] = '%WINDIR%'
 
 if node['firewall']['allow_consul']
@@ -33,7 +31,7 @@ service_name = node['consul']['service_name']
 poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
   shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?
-  not_if { windows? }
+  not_if { node.platform_family?('windows') }
   not_if { node['consul']['service_user'] == 'root' }
   not_if { node['consul']['create_service_user'] == false }
   notifies :restart, "consul_service[#{service_name}]", :delayed
@@ -55,7 +53,7 @@ consul_service service_name do |r|
   config_file config.path
   program install.consul_program
 
-  unless windows?
+  unless node.platform_family?('windows')
     user node['consul']['service_user']
     group node['consul']['service_group']
   end


### PR DESCRIPTION
- "chef-sugar" - this dependency was removed in #387, but `include_recipe` worked fine only because it is included by "firewall::default". We still don't need it, so it could be removed.
- "version" attribute is not defined in "consul_service" resource, it is not used and should not be passed there. Without chef-sugar it bombs this way:

```
       NoMethodError
       -------------
       undefined method `version' for ConsulCookbook::Resource::ConsulService
```