### PR TITLE
Fix "package" provider for "consul_installation" resource

### DIFF
--- a/libraries/consul_installation_package.rb
+++ b/libraries/consul_installation_package.rb
@@ -23,6 +23,10 @@ module ConsulCookbook
       provides(:package)
       inversion_attribute 'consul'
 
+      # The built-in resource "package" has it's own attribute named "options",
+      # so we should use an alias to access Poise inversion options.
+      alias res_options options
+
       # Set the default inversion options.
       # @return [Hash]
       # @api private
@@ -35,9 +39,9 @@ module ConsulCookbook
 
       def action_create
         notifying_block do
-          package options[:package_name] do
-            source options[:package_source]
-            version options[:version]
+          package res_options[:package_name] do
+            source res_options[:package_source]
+            version res_options[:version]
             action :upgrade
           end
         end
@@ -45,9 +49,9 @@ module ConsulCookbook
 
       def action_remove
         notifying_block do
-          package options[:package_name] do
-            source options[:package_source]
-            version options[:version]
+          package res_options[:package_name] do
+            source res_options[:package_source]
+            version res_options[:version]
             action :remove
           end
         end

--- a/libraries/consul_installation_package.rb
+++ b/libraries/consul_installation_package.rb
@@ -41,6 +41,7 @@ module ConsulCookbook
         notifying_block do
           package res_options[:package_name] do
             source res_options[:package_source]
+            provider res_options[:package_provider]
             version res_options[:version]
             action :upgrade
           end
@@ -51,6 +52,7 @@ module ConsulCookbook
         notifying_block do
           package res_options[:package_name] do
             source res_options[:package_source]
+            provider res_options[:package_provider]
             version res_options[:version]
             action :remove
           end

--- a/libraries/consul_installation_package.rb
+++ b/libraries/consul_installation_package.rb
@@ -37,7 +37,6 @@ module ConsulCookbook
         notifying_block do
           package options[:package_name] do
             source options[:package_source]
-            checksum options[:package_checksum]
             version options[:version]
             action :upgrade
           end
@@ -48,7 +47,6 @@ module ConsulCookbook
         notifying_block do
           package options[:package_name] do
             source options[:package_source]
-            checksum options[:package_checksum]
             version options[:version]
             action :uninstall
           end

--- a/libraries/consul_installation_package.rb
+++ b/libraries/consul_installation_package.rb
@@ -48,7 +48,7 @@ module ConsulCookbook
           package options[:package_name] do
             source options[:package_source]
             version options[:version]
-            action :uninstall
+            action :remove
           end
         end
       end


### PR DESCRIPTION
Fixes #389

- Removed an attribute "checksum" since it's not available for the built-in "package" resource and causes exceptions.
- Switched action from ":remove" to ":uninstall". The latter is not available for the built-in "package" resource and causes exceptions.
- Added an alias to access poise reverse options.
- Added an option "package_provider" allowing to explicitely set a provider for "package" resource, for example:
```ruby
node.default['consul']['options']['package_provider'] = Chef::Provider::Package::Dpkg
```

Refer to this comment for more details about what is broken there: therehttps://github.com/johnbellone/consul-cookbook/issues/389#issuecomment-272435788

@quulah, please verify - does it work for your case? 