### PR TITLE
Travis: Get "chefdk" package from "stable" channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-current-trusty
+      - chef-stable-trusty
     packages:
       - chefdk
 


### PR DESCRIPTION
"chefdk" package is not available in "current" channel anymore and causes TravisCI build failure:
https://travis-ci.org/johnbellone/consul-cookbook/builds/191897679