### PR TITLE
Cleanup attributes of consul_config resource

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -56,9 +56,7 @@ module ConsulCookbook
       attribute(:client_addr, kind_of: String)
       attribute(:data_dir, kind_of: String)
       attribute(:datacenter, kind_of: String)
-      attribute(:dev_mode, equal_to: [true, false], default: false)
       attribute(:disable_anonymous_signature, equal_to: [true, false], default: false)
-      attribute(:disable_compression, equal_to: [true, false], default: false)
       attribute(:disable_remote_exec, equal_to: [true, false], default: false)
       attribute(:disable_update_check, equal_to: [true, false], default: false)
       attribute(:dns_config, kind_of: [Hash, Mash])
@@ -73,12 +71,10 @@ module ConsulCookbook
       attribute(:performance, kind_of: [Hash, Mash])
       attribute(:ports, kind_of: [Hash, Mash])
       attribute(:protocol, kind_of: String)
-      attribute(:raft_multiplier, kind_of: Integer)
       attribute(:reap, equal_to: [true, false])
       attribute(:reconnect_timeout, kind_of: String)
       attribute(:reconnect_timeout_wan, kind_of: String)
       attribute(:recursor, kind_of: String)
-      attribute(:recursor_timeout, kind_of: String)
       attribute(:recursors, kind_of: Array)
       attribute(:retry_interval, kind_of: String)
       attribute(:retry_interval_wan, kind_of: String)
@@ -100,7 +96,6 @@ module ConsulCookbook
       attribute(:telemetry, kind_of: [Hash, Mash])
       attribute(:syslog_facility, kind_of: String)
       attribute(:translate_wan_addrs, equal_to: [true, false], default: false)
-      attribute(:udp_answer_limit, kind_of: Integer, default: 3)
       attribute(:ui, equal_to: [true, false], default: false)
       attribute(:ui_dir, kind_of: String)
       attribute(:unix_sockets, kind_of: [Hash, Mash])
@@ -112,7 +107,7 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_replication_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_compression disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name performance ports protocol reap reconnect_timeout reconnect_timeout_wan recursor recursor_timeout recursors retry_interval retry_interval_wan retry_join retry_join_ec2 retry_join_wan rejoin_after_leave serf_lan_bind serf_wan_bind server server_name session_ttl_min skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr statsite_prefix telemetry syslog_facility translate_wan_addrs udp_answer_limit ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches dev_mode unix_sockets}
+        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_replication_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name performance ports protocol reap reconnect_timeout reconnect_timeout_wan recursor recursors retry_interval retry_interval_wan retry_join retry_join_ec2 retry_join_wan rejoin_after_leave serf_lan_bind serf_wan_bind server server_name session_ttl_min skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr statsite_prefix telemetry syslog_facility translate_wan_addrs ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches unix_sockets}
         for_keeps << %i{bootstrap bootstrap_expect} if server
         for_keeps << %i{ca_file cert_file key_file} if tls?
         for_keeps = for_keeps.flatten

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -107,7 +107,75 @@ module ConsulCookbook
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
       def to_json
-        for_keeps = %i{acl_datacenter acl_default_policy acl_down_policy acl_master_token acl_replication_token acl_token acl_ttl addresses advertise_addr advertise_addr_wan atlas_acl_token atlas_infrastructure atlas_join atlas_token atlas_endpoint bind_addr check_update_interval client_addr data_dir datacenter disable_anonymous_signature disable_remote_exec disable_update_check dns_config domain enable_debug enable_syslog encrypt leave_on_terminate log_level node_name performance ports protocol reap reconnect_timeout reconnect_timeout_wan recursor recursors retry_interval retry_interval_wan retry_join retry_join_ec2 retry_join_wan rejoin_after_leave serf_lan_bind serf_wan_bind server server_name session_ttl_min skip_leave_on_interrupt start_join start_join_wan statsd_addr statsite_addr statsite_prefix telemetry syslog_facility translate_wan_addrs ui ui_dir verify_incoming verify_outgoing verify_server_hostname watches unix_sockets}
+        for_keeps = %i(
+          acl_datacenter
+          acl_default_policy
+          acl_down_policy
+          acl_master_token
+          acl_replication_token
+          acl_token
+          acl_ttl
+          addresses
+          advertise_addr
+          advertise_addr_wan
+          atlas_acl_token
+          atlas_endpoint
+          atlas_infrastructure
+          atlas_join
+          atlas_token
+          bind_addr
+          check_update_interval
+          client_addr
+          data_dir
+          datacenter
+          disable_anonymous_signature
+          disable_remote_exec
+          disable_update_check
+          dns_config
+          domain
+          enable_debug
+          enable_syslog
+          encrypt
+          leave_on_terminate
+          log_level
+          node_name
+          performance
+          ports
+          protocol
+          reap
+          reconnect_timeout
+          reconnect_timeout_wan
+          recursor
+          recursors
+          rejoin_after_leave
+          retry_interval
+          retry_interval_wan
+          retry_join
+          retry_join_ec2
+          retry_join_wan
+          serf_lan_bind
+          serf_wan_bind
+          server
+          server_name
+          session_ttl_min
+          skip_leave_on_interrupt
+          start_join
+          start_join_wan
+          statsd_addr
+          statsite_addr
+          statsite_prefix
+          syslog_facility
+          telemetry
+          translate_wan_addrs
+          ui
+          ui_dir
+          unix_sockets
+          verify_incoming
+          verify_outgoing
+          verify_server_hostname
+          watches
+        )
+
         for_keeps << %i{bootstrap bootstrap_expect} if server
         for_keeps << %i{ca_file cert_file key_file} if tls?
         for_keeps = for_keeps.flatten


### PR DESCRIPTION
Closes #367

1) Remove invalid attributes from `consul_config` resource:
- `dev_mode` is not supported.
- `raft_multiplier` should be nested into `performance` hash,
- `udp_answer_limit` should be nested into `dns_config` hash,
- `recursor_timeout` should be nested into `dns_config` hash,
- `disable_compression` should be nested into `dns_config` hash.
 
2) Unwrap the list of supported consul config options to multiple lines. Now It should be way easier to read and modify such list.