### PR TITLE
Remove FreeBSD platform support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,8 +18,6 @@ platforms:
   - name: centos-5.11
   - name: debian-8.2
   - name: debian-7.9
-  - name: freebsd-10.2
-    named_run_list: freebsd
   - name: windows-2012r2
 
 suites:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ _may_ work, but your mileage may vary.
 - Ubuntu 12.04, 14.04
 - Windows 2012r2
 - Debian 7.9, 8.2
-- FreeBSD 10.2
 
 ### Client
 Out of the box the default recipe installs and configures the Consul

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,6 @@ supports 'centos', '>= 6.4'
 supports 'redhat', '>= 6.4'
 supports 'ubuntu', '>= 12.04'
 supports 'solaris2'
-supports 'freebsd'
 supports 'arch'
 supports 'windows'
 

--- a/test/fixtures/policies/default.rb
+++ b/test/fixtures/policies/default.rb
@@ -3,5 +3,4 @@ default_source :supermarket
 default_source :chef_repo, '..'
 cookbook 'consul', path: '../../..'
 run_list 'consul_spec::default'
-named_run_list :freebsd, 'freebsd::default', 'sudo::default', run_list
 named_run_list :client, 'consul::default'


### PR DESCRIPTION
Currently, "poise-service" cookbook doesn't support FreeBSD,
so "consul" cookbook is not compatible with FreeBSD platform too.

Failure details: https://github.com/poise/poise-service/issues/36