### PR TITLE
Properly sort consul configuration

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -183,7 +183,7 @@ module ConsulCookbook
         config = to_hash.keep_if do |k, _|
           for_keeps.include?(k.to_sym)
         end.merge(options)
-        JSON.pretty_generate(Hash[config.sort], quirks_mode: true)
+        JSON.pretty_generate(Hash[config.sort_by { |k, _| k.to_s }], quirks_mode: true)
       end
 
       def tls?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -104,7 +104,7 @@ module ConsulCookbook
       # 1 is command not found
       # 3 is service not found
       exit_code = shell_out!(%("#{nssm_exe}" status consul), returns: [0, 1, 3]).exitstatus
-      exit_code.zero?
+      exit_code == 0
     end
 
     def nssm_service_status?(expected_status)


### PR DESCRIPTION
Simple sort compare key & values. It fails for hash values.

For instance:

```ruby
{:data_dir=>"/var/lib/consul",
 :client_addr=>"0.0.0.0",
 :ports=>{"dns"=>-1, "http"=>8500, "rpc"=>8400, "serf_lan"=>8301, "serf_wan"=>8302, "server"=>8300},
 :enable_syslog=>false,
 :retry_join=>["consul01-par.kitchen"],
 :node_name=>"ip-10-0-64-236.us-west-2.compute.internal",
 :server=>false,
 :datacenter=>"par",
 :domain=>"consul",
 :addresses=>{"http"=>"0.0.0.0"},
 :acl_datacenter=>"par",
 :disable_update_check=>true,
 :leave_on_terminate=>false,
 :advertise_addr=>"10.0.64.236",
 :encrypt=>"/AKlGGZMMSUsJLit/+etBw==",
 :verify_incoming=>false,
 :verify_outgoing=>false,
 "node_meta"=>{"rack"=>nil}}
```

will raise `ArgumentError: comparison of Array with Array failed`.

Sorting by keys is sufficient

Fix #410

Change-Id: Ieaf05a019c4d636ae8457046ee4e3bf8f697296a