### PR TITLE
fixing permission of generated config

### DIFF
--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -60,7 +60,7 @@ module ConsulCookbook
             unless platform?('windows')
               owner new_resource.user
               group new_resource.group
-              mode '0640'
+              mode '0644'
             end
           end
         end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -73,7 +73,7 @@ describe file("#{confd_dir}/consul_definition_check.json") do
   it { should be_file }
   it { should be_owned_by 'root' }
   it { should be_grouped_into 'consul' }
-  its('mode') { should cmp '0640' }
+  its('mode') { should cmp '0644' }
 end
 
 describe file("#{confd_dir}/consul_watch_check.json") do


### PR DESCRIPTION
There's no need in such strict options for a configuration file. However if there is it should be configurable for an enduser.