### PR TITLE
consul_config: Add "node_id" option

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -71,6 +71,7 @@ module ConsulCookbook
       attribute(:key_file, kind_of: String)
       attribute(:leave_on_terminate, equal_to: [true, false], default: false)
       attribute(:log_level, equal_to: %w(INFO DEBUG WARN), default: 'INFO')
+      attribute(:node_id, kind_of: String)
       attribute(:node_name, kind_of: String)
       attribute(:performance, kind_of: [Hash, Mash])
       attribute(:ports, kind_of: [Hash, Mash])
@@ -147,6 +148,7 @@ module ConsulCookbook
           leave_on_terminate
           log_level
           node_name
+          node_id
           performance
           ports
           protocol


### PR DESCRIPTION
Fixes #418 

`node_id` option is available in Consul 0.7.3+