### PR TITLE
Consul 0.7.5 & Windows Fixes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
 
-default['consul']['version'] = '0.7.4'
+default['consul']['version'] = '0.7.5'
 
 # Windows only
 default['consul']['service']['nssm_params'] = {

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -103,6 +103,7 @@ module ConsulCookbook
           when '0.7.2' then '4403357fbfddbcdd0742946cab7856638cb0f15898c75d79d155753621d60b0c'
           when '0.7.3' then '08dd9af590a6c6ecd629e532083bd898b42c6425d08aa9f62b8f090a6dd65826'
           when '0.7.4' then 'a66cd4efdff376e7fd5c22d2710d7ef6734562c46df80a05e3144222965d9a97'
+          when '0.7.5' then '60c1685bfbefe55d0ac67f37d4bc88752a204609221d0cc4425452f1ffc2e42b'
           end
         when 'darwin-i386'
           case resource.version
@@ -116,6 +117,7 @@ module ConsulCookbook
           when '0.7.2' then '23e6e8dd14c2be02fd095a865edd1725f5ccdbce1109ad5f70832866012d1d7f'
           when '0.7.3' then 'cf369542e30c5aa22967459b25fec284284d292ff25e801bdcd1a5f37f1a5143'
           when '0.7.4' then '7638e80c9db050ef8d63bad3baa338985da1a1bd4657f3b2fc4222d105c673a3'
+          when '0.7.5' then '9ff8798a94bab99fb2387afae5bc0fc2844a304675abbceb9315292019a8f582'
           end
         when 'solaris-amd64'
           case resource.version
@@ -127,6 +129,7 @@ module ConsulCookbook
           when '0.7.2' then 'f1ccaf9d9dd62544323e130cee7221df2a6d4b577e9e4a120db357e59782f12d'
           when '0.7.3' then '49b13f83f8099537e72adc1bb34b6cb70b3699aa10245db4b8ef1f48c6e0b007'
           when '0.7.4' then '0300ffa4d1007b00bca37112cf934d3e281afdc300ce336735bbf3a33ebcfc19'
+          when '0.7.5' then 'aa3705a958d0403e2ddacaa75c1d3ede5f290b0ef3a60e6e24976f2d8f32d840'
           end
         when 'windows-amd64'
           case resource.version
@@ -140,6 +143,7 @@ module ConsulCookbook
           when '0.7.2' then '7a5ec31018328a3764f22327c940765c9cd99e57c6759fc43fbfed8318d5e379'
           when '0.7.3' then 'ec80a931603bf585704e338e6cb497af9aa58ebdae5e3442a3f78f7027d80b66'
           when '0.7.4' then 'c2e071ebae166d4cfdf894966b2966026cf9175d394001704f68bcbccaa8e446'
+          when '0.7.5' then '6cc64b1bb949f926d403e0436d02bf740844cf268076cf6d3d345361c1aa5293'
           end
         when 'windows-i386'
           case resource.version
@@ -156,6 +160,7 @@ module ConsulCookbook
           when '0.7.2' then 'c041dc43995df3505d9146e3a2f532bfc491c49fb644bd1e2ceead7d7dc3011c'
           when '0.7.3' then '87a7169bd5298e179a3bbd2f30b3447c09023dc771c97d083779090655bf0a5f'
           when '0.7.4' then 'ede957f736758a40fb8e3e33eb423a71226db46085fe1507d880a0ce393e9658'
+          when '0.7.5' then '7ea88aa53026cb14bab6a68d5b64c43515ea39552594ae399978fc13bcd74707'
           end
         when 'linux-amd64'
           case resource.version
@@ -172,6 +177,7 @@ module ConsulCookbook
           when '0.7.2' then 'aa97f4e5a552d986b2a36d48fdc3a4a909463e7de5f726f3c5a89b8a1be74a58'
           when '0.7.3' then '901a3796b645c3ce3853d5160080217a10ad8d9bd8356d0b73fcd6bc078b7f82'
           when '0.7.4' then '23a61773bee9b29198cc1f8fe2e62c320f82f95006ff70840c15c1e58eead73b'
+          when '0.7.5' then '40ce7175535551882ecdff21fdd276cef6eaab96be8a8260e0599fadb6f1f5b8'
           end
         when 'linux-i386'
           case resource.version
@@ -188,6 +194,7 @@ module ConsulCookbook
           when '0.7.2' then '43b22bcd04e74445c3ea6c143b3acbfe5546d6792c28d123ef5832cd8f96162f'
           when '0.7.3' then 'b15e96a1b5833b08d785d67b8f2465a9a0185e34149855943717dd818b347750'
           when '0.7.4' then '7fe40af0825b2c6ab6c7e4e3e7d68471cccbd54f9a1513ad622b832cfda5fa07'
+          when '0.7.5' then '8abf0189776ecc5c8746e12021b6cfe6d96e0b4689ce4a4948b7e3faa07f3025'
           end
         when 'linux-arm'
           case resource.version
@@ -201,6 +208,7 @@ module ConsulCookbook
           when '0.7.2' then 'e18934a3a38b980bc0cfaa8d74379a6bfe58cf1ecf4b164e28ff37dd6c7198b0'
           when '0.7.3' then 'a2d2d2cf194e3768aae7c3cdf140a056bf2534f4c83fb7a66cfbd4090c98773e'
           when '0.7.4' then 'bfd9cbef9c7c9f2128704940323d1727d8edbbd595c8d82aba923e04f04b266d'
+          when '0.7.5' then 'df4bc38eff4305632d29c5650fbb7e7ff97b8ef12a964fd8ee5f691849c51711'
           end
         end
       end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -55,6 +55,7 @@ module ConsulCookbook
         {
           'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
           'PATH' => '/usr/local/bin:/usr/bin:/bin',
+          'SHELL' => node['consul']['service_shell'],
         }
       end
     end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -51,12 +51,16 @@ module ConsulCookbook
         "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end
 
+      def shell_environment
+        shell = node['consul']['service_shell']
+        shell.nil? ? {} : { 'SHELL' => shell }
+      end
+
       def default_environment
         {
           'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
-          'PATH' => '/usr/local/bin:/usr/bin:/bin',
-          'SHELL' => node['consul']['service_shell'],
-        }
+          'PATH' => '/usr/local/bin:/usr/bin:/bin'
+        }.merge(shell_environment)
       end
     end
   end

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -59,7 +59,7 @@ module ConsulCookbook
       def default_environment
         {
           'GOMAXPROCS' => [node['cpu']['total'], 2].max.to_s,
-          'PATH' => '/usr/local/bin:/usr/bin:/bin'
+          'PATH' => '/usr/local/bin:/usr/bin:/bin',
         }.merge(shell_environment)
       end
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -112,10 +112,11 @@ module ConsulCookbook
     end
 
     # Returns a hash of mismatched params
-    def check_nssm_params
+    def check_nssm_params(extra = {})
+      params = node['consul']['service']['nssm_params'].merge extra
       # nssm can only get certain values
-      params = node['consul']['service']['nssm_params'].select { |k, _v| nssm_params.include? k.to_s }
-      params.each.each_with_object({}) do |(k, v), mismatch|
+      to_check = params.select { |k, _v| nssm_params.include? k.to_s }
+      to_check.each.each_with_object({}) do |(k, v), mismatch|
         # shell_out! returns values with null bytes, need to delete them before we evaluate
         unless shell_out!(%("#{nssm_exe}" get consul #{k}), returns: [0]).stdout.delete("\0").strip.eql? v.to_s
           mismatch[k] = v

--- a/test/integration/spec_helper.rb
+++ b/test/integration/spec_helper.rb
@@ -1,3 +1,3 @@
 def consul_version
-  '0.7.4'
+  '0.7.5'
 end

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -16,7 +16,7 @@ describe ConsulCookbook::Resource::ConsulService do
       allow(shellout).to receive(:stderr)
       allow(shellout).to receive(:run_command)
       allow(shellout).to receive(:exitstatus)
-      allow(shellout).to receive(:stdout).and_return("Consul v0.6.0\nConsul Protocol: 3 (Understands back to: 1)\n")
+      allow(shellout).to receive(:stdout).and_return("Consul v0.7.5\nConsul Protocol: 3 (Understands back to: 1)\n")
 
       # Stub admin_user method since we are testing a Windows host via Linux
       # Fixed in https://github.com/poise/poise/commit/2f42850c82e295af279d060155bcd5c7ebb31d6a but not released yet
@@ -26,19 +26,16 @@ describe ConsulCookbook::Resource::ConsulService do
     recipe 'consul::default'
 
     it do
-      skip('Add poise inversion system to consul_service otherwise windows tests will not pass')
       is_expected.to create_directory('C:\Program Files\consul\conf.d')
     end
 
     it do
-      skip('Add poise inversion system to consul_service otherwise windows tests will not pass')
       is_expected.to create_directory('C:\Program Files\consul\data')
     end
 
     it do
-      skip('Add poise inversion system to consul_service otherwise windows tests will not pass')
       expect(chef_run).to install_nssm('consul').with(
-        program: 'C:\Program Files\consul\0.7.1\consul.exe',
+        program: 'C:\Program Files\consul\0.7.5\consul.exe',
         args: 'agent -config-file="""C:\Program Files\consul\consul.json""" -config-dir="""C:\Program Files\consul\conf.d"""'
       )
     end


### PR DESCRIPTION
* Bump default version to 0.7.5
* Fixed upgrading issue on Windows
  * The NSSM service would not use the new binary location
  * Added extends to certain resources to ensure we're using the Consul Cookbook helper methods
* Added SHELL environment variable to default_environment hash
  * To make it easier to troubleshoot why script checks don't fire when consul is launched with systemd
* Re-enabled the Windows Service spec tests as they seem to work locally for me now