### PR TITLE
Support nssm cookbook 3.0

### DIFF
--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -30,10 +30,14 @@ module ConsulCookbook
           end
 
           nssm 'consul' do
-            action :install
             program new_resource.program
-            params new_resource.nssm_params.select { |_k, v| v != '' }
             args command(new_resource.config_file, new_resource.config_dir)
+            if respond_to? :parameters
+              parameters new_resource.nssm_params.select { |_k, v| v != '' }
+            else
+              params new_resource.nssm_params.select { |_k, v| v != '' }
+            end
+            action :install
             not_if { nssm_service_installed? }
           end
 


### PR DESCRIPTION
Nssm cookbook version 3.0 has been release with a breaking change.
The 'params' property has been renamed in 'parameters' for Chef 13 compat.

This code use 'parameters' if the resource expose this property and 'params'
otherwise.

**Cc:** @aboten