### PR TITLE
attributes: explicit node.default server->false

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,13 +37,10 @@ suites:
           acl_default_policy: deny
     excludes:
       - windows-2012r2
+
   - name: client
     named_run_list: client
-    attributes:
-      consul:
-        config:
-          server: false
-          bootstrap_expect: 1
+
   - name: git
     attributes:
       go:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['create_service_user'] = true
 
+default['consul']['config']['server'] = false
 default['consul']['config']['owner'] = 'consul'
 default['consul']['config']['group'] = 'consul'
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,6 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['create_service_user'] = true
 
-default['consul']['config']['server'] = false
 default['consul']['config']['owner'] = 'consul'
 default['consul']['config']['group'] = 'consul'
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -190,8 +190,9 @@ module ConsulCookbook
         for_keeps << %i(ca_file cert_file key_file) if tls?
         for_keeps = for_keeps.flatten
 
-        config = to_hash.keep_if do |k, _|
-          for_keeps.include?(k.to_sym)
+        # Filter out undefined attributes and keep only those listed above
+        config = to_hash.keep_if do |k, v|
+          !v.nil? && for_keeps.include?(k.to_sym)
         end.merge(options)
         JSON.pretty_generate(Hash[config.sort_by { |k, _| k.to_s }], quirks_mode: true)
       end

--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -89,7 +89,7 @@ module ConsulCookbook
       attribute(:rejoin_after_leave, equal_to: [true, false], default: true)
       attribute(:serf_lan_bind, kind_of: String)
       attribute(:serf_wan_bind, kind_of: String)
-      attribute(:server, equal_to: [true, false], default: true)
+      attribute(:server, equal_to: [true, false])
       attribute(:server_name, kind_of: String)
       attribute(:session_ttl_min, kind_of: String)
       attribute(:skip_leave_on_interrupt, equal_to: [true, false], default: false)

--- a/test/spec/libraries/consul_config_spec.rb
+++ b/test/spec/libraries/consul_config_spec.rb
@@ -39,7 +39,6 @@ describe ConsulCookbook::Resource::ConsulConfig do
         .with(content: <<-EOH.chomp.gsub(/^        /, ''))
         {
           "recursor": "foo",
-          "server": true,
           "translate_wan_addrs": true,
           "verify_incoming": false,
           "verify_outgoing": false


### PR DESCRIPTION
closes #423 

Wasn't sure how you'd prefer to add tests, since server:false is explicitly set in `.kitchen.yml`. Happy to iterate on that as needed.