### PR TITLE
Update unit tests configuration

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,9 @@
+[local_phases]
+unit = "bundle exec rspec test/spec/"
+lint = 'cookstyle --display-cop-names --extra-details'
+syntax = "foodcritic ."
+provision = "echo skipping"
+deploy = "echo skipping"
+smoke = "echo skipping"
+functional = "echo skipping"
+cleanup = "echo skipping"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   include:
     - script:
       - bundle install
-      - bundle exec rake
+      - chef exec delivery local all
       env: UNIT_AND_LINT=1
 
 notifications:

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,8 @@
+source 'https://supermarket.chef.io'
+
+metadata
+
+group :integration do
+  cookbook 'selinux'
+  cookbook 'consul_spec', path: 'test/fixtures/cookbooks/consul_spec'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :lint do
 end
 
 group :unit, :integration do
-  gem 'chef-dk', '~> 1.0'
+  gem 'berkshelf'
   gem 'chefspec'
   gem 'rubyzip'
   gem 'serverspec'

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,14 @@
+# This gemfile provides additional gems for testing and releasing this cookbook
+# It is meant to be installed on top of ChefDK which provides the majority
+# of the necessary gems for testing this cookbook
+#
+# Run 'chef exec bundle install' to install these dependencies
+
 source 'https://rubygems.org'
+
+gem 'berkshelf'
 gem 'poise', '~> 2.2'
-gem 'poise-service', '~> 1.0'
 gem 'poise-boiler'
-gem 'chef-sugar'
-
-group :lint do
-  gem 'cookstyle', '~> 1.0'
-  gem 'rubocop'
-  gem 'foodcritic'
-end
-
-group :unit, :integration do
-  gem 'berkshelf'
-  gem 'chefspec'
-  gem 'rubyzip'
-  gem 'serverspec'
-  gem 'rb-readline'
-end
-
-group :development do
-  gem 'awesome_print'
-  gem 'stove'
-end
-
-group :doc do
-  gem 'yard'
-end
+gem 'poise-service', '~> 1.0'
+gem 'rb-readline'
+gem 'stove'

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,3 +25,5 @@ depends 'poise-service', '~> 1.4'
 
 source_url 'https://github.com/johnbellone/consul-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/johnbellone/consul-cookbook/issues' if respond_to?(:issues_url)
+
+chef_version '>= 12.1' if respond_to?(:chef_version)

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/policyfile'
+require 'chefspec/berkshelf'
 require 'poise_boiler/spec_helper'
 require_relative '../../libraries/helpers'
 

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -2,6 +2,3 @@ require 'chefspec'
 require 'chefspec/berkshelf'
 require 'poise_boiler/spec_helper'
 require_relative '../../libraries/helpers'
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start


### PR DESCRIPTION
Currently we have unit tests failed because of a `cheffish` gem conflict (is required by `chef-dk` gem). This PR removes some unnecessary gem dependencies and introduces Chef Delivery CLI for running tests, like Chef Software does that for their cookbooks.

* Use Berkshelf for dep resolving in ChefSpec.
Policyfile resolver for ChefSpec requires "chef-dk" gem, which has pretty big dependency tree.
So, for unit tests it's better just to use Berkshelf.
* Disable CodeClimate reporter
* Gemfile: Remove unnecessary gems
* Use Chef Delivery CLI to run spec and style checks
* Add "chef_version" to metadata