### PR TITLE
Calling /etc/init.d/consul restart sometimes ends up with a stopped …

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -39,7 +39,7 @@ _start() {
 }
 
 _stop() {
-  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @stop_signal %>"
+  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --retry="<%= @stop_signal %>"/30/KILL/5
 }
 
 _status() {


### PR DESCRIPTION
…consul process. The reason is that the init script sometimes starts consul before it was completely stopped. During a cookbook upgrade from version 2.1.3 to 2.2.0 this took down the consul agent on a number of our servers. 
This can be easily reproduced runnning:

 watch -n 0.5 -e '/etc/init.d/consul restart; sleep 0.1; /etc/init.d/consul status'

Adding the --retry parameter lets start-stop-daemon wait until the consul process is actually stopped.