### PR TITLE
Improved the _start()  method in the sysv initscript. Until now a sta…

### DIFF
--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -32,10 +32,27 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 _start() {
   touch $logfile
   chown $user $logfile
+  echo "Starting consul"
   start-stop-daemon --start --quiet --background \
       --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
       --chuid $user --chdir "<%= @directory %>" \
       --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >> $logfile 2>&1"
+
+  echo -n "Waiting for consul daemon to be listening..."
+  for i in `seq 1 30`; do
+    if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
+      echo " FAIL: consul process died"
+      return 2
+    fi
+    if "$exec" info >/dev/null; then
+      echo " OK"
+      return 0
+    fi
+    echo -n .
+    sleep 1
+  done
+  echo " FAIL: consul process is alive, but is not listening."
+  return 2
 }
 
 _stop() {

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -112,6 +112,7 @@ _status_q() {
 _wait_for_listening() {
     echo -n "Waiting for consul daemon to be listening..."
     for i in `seq 1 30`; do
+        sleep 1
         # if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
         if ! _status_q; then
             echo " FAIL: consul process died"
@@ -122,7 +123,6 @@ _wait_for_listening() {
             return 0
         fi
         echo -n .
-        sleep 1
     done
     echo " FAIL: consul process is alive, but is not listening."
     return 2

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -38,21 +38,7 @@ _start() {
       --chuid $user --chdir "<%= @directory %>" \
       --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >> $logfile 2>&1"
 
-  echo -n "Waiting for consul daemon to be listening..."
-  for i in `seq 1 30`; do
-    if ! _status_q; then
-      echo " FAIL: consul process died"
-      return 2
-    fi
-    if "$exec" info >/dev/null; then
-      echo " OK"
-      return 0
-    fi
-    echo -n .
-    sleep 1
-  done
-  echo " FAIL: consul process is alive, but is not listening."
-  return 2
+  _wait_for_listening
 }
 
 _stop() {
@@ -121,6 +107,25 @@ _restart() {
 
 _status_q() {
     _status >/dev/null 2>&1
+}
+
+_wait_for_listening() {
+  echo -n "Waiting for consul daemon to be listening..."
+  for i in `seq 1 30`; do
+    # if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
+    if ! _status_q; then
+      echo " FAIL: consul process died"
+      return 2
+    fi
+    if "$exec" info >/dev/null; then
+      echo " OK"
+      return 0
+    fi
+    echo -n .
+    sleep 1
+  done
+  echo " FAIL: consul process is alive, but is not listening."
+  return 2
 }
 
 case "$1" in

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -40,7 +40,7 @@ _start() {
 
   echo -n "Waiting for consul daemon to be listening..."
   for i in `seq 1 30`; do
-    if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
+    if ! _status_q; then
       echo " FAIL: consul process died"
       return 2
     fi

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -30,27 +30,27 @@ export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 . /lib/lsb/init-functions
 
 _start() {
-  touch $logfile
-  chown $user $logfile
-  echo "Starting consul"
-  start-stop-daemon --start --quiet --background \
-      --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
-      --chuid $user --chdir "<%= @directory %>" \
-      --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >> $logfile 2>&1"
+    touch $logfile
+    chown $user $logfile
+    echo "Starting consul"
+    start-stop-daemon --start --quiet --background \
+        --pidfile $pidfile<% unless @pid_file_external %> --make-pidfile<% end %> \
+        --chuid $user --chdir "<%= @directory %>" \
+        --startas /bin/bash -- -c "exec $exec <%= @daemon_options %> >> $logfile 2>&1"
 
-  _wait_for_listening
+    _wait_for_listening
 }
 
 _stop() {
-  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --retry="<%= @stop_signal %>"/30/KILL/5
+    start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --retry="<%= @stop_signal %>"/30/KILL/5
 }
 
 _status() {
-  status_of_proc -p $pidfile $exec $prog
+    status_of_proc -p $pidfile $exec $prog
 }
 
 _reload() {
-  start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @reload_signal %>"
+    start-stop-daemon --stop --quiet --pidfile $pidfile --user $user --signal "<%= @reload_signal %>"
 }
 
 <%- else -%>
@@ -65,9 +65,9 @@ _start() {
 
     echo -n $"Starting <%= @name %>: "
     daemon \
-         --pidfile=$pidfile \
-         --user=$user \
-         " { $exec <%= @daemon_options %> >> $logfile 2>&1 & } ; echo \$! >| $pidfile "
+        --pidfile=$pidfile \
+        --user=$user \
+        " { $exec <%= @daemon_options %> >> $logfile 2>&1 & } ; echo \$! >| $pidfile "
      RETVAL=$?
      echo
      [ $RETVAL -eq 0 ] && touch $lockfile
@@ -110,22 +110,22 @@ _status_q() {
 }
 
 _wait_for_listening() {
-  echo -n "Waiting for consul daemon to be listening..."
-  for i in `seq 1 30`; do
-    # if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
-    if ! _status_q; then
-      echo " FAIL: consul process died"
-      return 2
-    fi
-    if "$exec" info >/dev/null; then
-      echo " OK"
-      return 0
-    fi
-    echo -n .
-    sleep 1
-  done
-  echo " FAIL: consul process is alive, but is not listening."
-  return 2
+    echo -n "Waiting for consul daemon to be listening..."
+    for i in `seq 1 30`; do
+        # if ! start-stop-daemon --quiet --stop --test --pidfile $pidfile --user $user; then
+        if ! _status_q; then
+            echo " FAIL: consul process died"
+            return 2
+        fi
+        if "$exec" info >/dev/null; then
+            echo " OK"
+            return 0
+        fi
+        echo -n .
+        sleep 1
+    done
+    echo " FAIL: consul process is alive, but is not listening."
+    return 2
 }
 
 case "$1" in


### PR DESCRIPTION
…rt of the consul agent followed by a reload will interrupt the start process and the consul agent will be stopped

You can simply reproduce this by calling:
/etc/init.d/consul restart; /etc/init.d/consul reload; /etc/init.d/consul status

 This is likely to happen if you make a change in a wrapper cookbook that triggeres a consul restart and another change which triggeres a consul reload. Your consul agent will be stopped afterwards.

  To fix this this change will make sure the consul service is started before leaving the _start() method.