### PR TITLE
Lock nssm dependency to version ~> 2.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ supports 'arch'
 supports 'windows'
 
 depends 'build-essential'
-depends 'nssm'
+depends 'nssm', '~> 2.0'
 depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'


### PR DESCRIPTION
Fixes #436 by keeping the the nssm cookbook under 3.0.0