### PR TITLE
Fix /opt/consul permissions

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -76,7 +76,7 @@ module ConsulCookbook
       def action_enable
         notifying_block do
           directory new_resource.data_dir do
-            recursive true
+            recursive false
             owner new_resource.user
             group new_resource.group
             mode '0750'


### PR DESCRIPTION
The recursive call on the directory in service provider overrides the configuration previously setup for the /opt/consul directory