### PR TITLE
modify consul_acl resource to support SSL options

### DIFF
--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -39,6 +39,26 @@ module ConsulCookbook
       # @return [String]
       attribute(:rules, kind_of: String, default: '')
 
+      # @!attribute client_cert
+      # @return [String]
+      attribute(:client_cert, kind_of: String, default: nil)
+
+      # @!attribute client_key
+      # @return [String]
+      attribute(:client_key, kind_of: String, default: nil)
+
+      # @!attribute ca_file
+      # @return [String]
+      attribute(:ca_file, kind_of: String, default: nil)
+
+      # @!attribute ca_path
+      # @return [String]
+      attribute(:ca_path, kind_of: String, default: nil)
+
+      # @!attribute cert_store
+      # @return [String]
+      attribute(:cert_store, kind_of: String, default: nil)
+
       def to_acl
         { 'ID' => id, 'Type' => type, 'Name' => acl_name, 'Rules' => rules }
       end
@@ -79,7 +99,18 @@ module ConsulCookbook
         Diplomat.configure do |config|
           config.url = new_resource.url
           config.acl_token = new_resource.auth_token
-          config.options = { request: { timeout: 10 } }
+          ssl_options = {}
+          ssl_options[:client_cert] = new_resource.client_cert unless new_resource.client_cert.nil?
+          ssl_options[:client_key] = new_resource.client_key unless new_resource.client_key.nil?
+          ssl_options[:ca_file] = new_resource.ca_file unless new_resource.ca_file.nil?
+          ssl_options[:ca_path] = new_resource.ca_path unless new_resource.ca_path.nil?
+          ssl_options[:cert_store] = new_resource.cert_store unless new_resource.cert_store.nil?
+
+          if ssl_options.empty?
+            config.options = { request: { timeout: 10 } }
+          else
+            config.options = { ssl: ssl_options, request: { timeout: 10 } }
+          end
         end
       end
 

--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -39,25 +39,9 @@ module ConsulCookbook
       # @return [String]
       attribute(:rules, kind_of: String, default: '')
 
-      # @!attribute client_cert
-      # @return [String]
-      attribute(:client_cert, kind_of: String, default: nil)
-
-      # @!attribute client_key
-      # @return [String]
-      attribute(:client_key, kind_of: String, default: nil)
-
-      # @!attribute ca_file
-      # @return [String]
-      attribute(:ca_file, kind_of: String, default: nil)
-
-      # @!attribute ca_path
-      # @return [String]
-      attribute(:ca_path, kind_of: String, default: nil)
-
-      # @!attribute cert_store
-      # @return [String]
-      attribute(:cert_store, kind_of: String, default: nil)
+      # @!attribute ssl
+      # @return [Hash]
+      attribute(:ssl, kind_of: Hash, default: {})
 
       def to_acl
         { 'ID' => id, 'Type' => type, 'Name' => acl_name, 'Rules' => rules }
@@ -99,18 +83,7 @@ module ConsulCookbook
         Diplomat.configure do |config|
           config.url = new_resource.url
           config.acl_token = new_resource.auth_token
-          ssl_options = {}
-          ssl_options[:client_cert] = new_resource.client_cert unless new_resource.client_cert.nil?
-          ssl_options[:client_key] = new_resource.client_key unless new_resource.client_key.nil?
-          ssl_options[:ca_file] = new_resource.ca_file unless new_resource.ca_file.nil?
-          ssl_options[:ca_path] = new_resource.ca_path unless new_resource.ca_path.nil?
-          ssl_options[:cert_store] = new_resource.cert_store unless new_resource.cert_store.nil?
-
-          if ssl_options.empty?
-            config.options = { request: { timeout: 10 } }
-          else
-            config.options = { ssl: ssl_options, request: { timeout: 10 } }
-          end
+          config.options = { ssl: new_resource.ssl, request: { timeout: 10 } }
         end
       end
 


### PR DESCRIPTION
Currently the `consul_acl` resource breaks with an SSL only Consul cluster. This PR adds ability to pass optional SSL attributes to enable using the resource in such situations.