### PR TITLE
Remove the notification for consul service restart

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,16 +6,15 @@
 #
 node.default['nssm']['install_location'] = '%WINDIR%'
 
-service_name = node['consul']['service_name']
 poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
   shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?
   not_if { node.platform_family?('windows') }
   not_if { node['consul']['service_user'] == 'root' }
   not_if { node['consul']['create_service_user'] == false }
-  notifies :restart, "consul_service[#{service_name}]", :delayed
 end
 
+service_name = node['consul']['service_name']
 config = consul_config service_name do |r|
   node['consul']['config'].each_pair { |k, v| r.send(k, v) }
   notifies :reload, "consul_service[#{service_name}]", :delayed


### PR DESCRIPTION
Fixes an issue #438

We don't need to notify consul service by changes of `poise_service_user` resource:

- It is useless for initial converge because the service will start automatically after and
it happens _after_ user creation.

- We should not restart the service automatically even if the name of service user has been
changed for an existing installation. In this case the restart is harmful, because consul data
(/var/lib/consul/*) is still owned by an old user, so it should be handled by a special procedure: 1)stop service, 2)change data files ownership, 3)start service.
So, it's out of this cookbook's scope.