### PR TITLE
Use "service_user" and "service_group" attributes as defaults for resource params 

### DIFF
--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -24,11 +24,11 @@ module ConsulCookbook
       # @!attribute user
       # The service user the Consul process runs as.
       # @return [String]
-      attribute(:user, kind_of: String, default: 'consul')
+      attribute(:user, kind_of: String, default: lazy { node['consul']['service_user'] })
       # @!attribute group
       # The service group the Consul process runs as.
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['service_group'] })
       # @!attribute environment
       # The environment that the Consul process starts with.
       # @return [String]

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -21,11 +21,11 @@ module ConsulCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: 'consul')
+      attribute(:user, kind_of: String, default: lazy { node['consul']['service_user'] })
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'consul')
+      attribute(:group, kind_of: String, default: lazy { node['consul']['service_group'] })
 
       # @!attribute type
       # @return [String]

--- a/test/spec/libraries/consul_watch_spec.rb
+++ b/test/spec/libraries/consul_watch_spec.rb
@@ -6,6 +6,8 @@ describe ConsulCookbook::Resource::ConsulWatch do
   let(:chefspec_options) { { platform: 'ubuntu', version: '14.04' } }
   before do
     default_attributes['consul'] = {
+      'service_user' => 'consul',
+      'service_group' => 'consul',
       'service' => {
         'config_dir' => '/etc/consul/conf.d',
       },


### PR DESCRIPTION
It looks like a mistake existing for a long time already.
Regardless of their names, attributes `['consul']['service_user']` and `['consul']['service_group']` don't actually affect the user running Consul as well as permissions for `['consul']['config']['data_dir']` directory.

This PR fixes that. Now `user` and `group` params of `consul_service` resource have default values as `['consul']['service_user']` and `['consul']['service_group']` appropriately.