### PR TITLE
Remove default attributes ['config']['owner'] and ['config']['group']

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -102,7 +102,6 @@ suites:
       consul:
         config: &default-config
           owner: root
-          group: consul
           bootstrap: true
           server: true
           datacenter: FortMeade

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,6 @@ suites:
       consul:
         config: &default-config
           owner: root
-          group: consul
           ui: true
           bootstrap: true
           server: true

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ end
 ```
 
 ### Security
-The default recipe makes the Consul configuration writable by the consul service user to avoid breaking existing implementations. You can make this more secure by setting the `node['consul']['config']` attribute to `root`, or set the `owner` property of `consul_config` explicitly:
+The default recipe makes the Consul configuration writable by the consul service
+user to avoid breaking existing implementations. You can make this more secure
+by setting the `node['consul']['config']['owner']` attribute to `root`, or set
+the `owner` property of `consul_config` explicitly:
 
 ```ruby
 # attributes file

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,8 +10,6 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['create_service_user'] = true
 
-default['consul']['config']['owner'] = 'consul'
-default['consul']['config']['group'] = 'consul'
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
 default['consul']['config']['data_dir'] = data_path
 default['consul']['config']['ca_file'] = join_path config_prefix_path, 'ssl', 'CA', 'ca.crt'


### PR DESCRIPTION
These attributes are redundant in the default.rb attribute file because they cause
a confusion about how the default values of `consul_config`'s `owner` and `group` params are actually determined.

Due to Poise inversion options, the node's attribute will always have a precedence.
They are designed to be used by cookbook end-users in their wrapper cookbooks.

We already have default values defined in the resource itself:
https://github.com/johnbellone/consul-cookbook/blob/eebc1299cefb6d766218904ea372566cc84bf373/libraries/consul_config.rb#L21-L26

Default values of `['service_owner']` and `['service_group']` are _"consul"_ too, so we can
remove  `['config']['owner']` and ` ['config']['group'] ` without any effect.

Fixes #405