### PR TITLE
Do not perform parameters escaping for nssm 3.0.1

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,7 +46,7 @@ module ConsulCookbook
 
     def command(config_file, config_dir)
       if windows?
-        %(agent -config-file="""#{config_file}""" -config-dir="""#{config_dir}""")
+        %(agent -config-file="#{config_file}" -config-dir="#{config_dir}")
       else
         "/usr/local/bin/consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ supports 'arch'
 supports 'windows'
 
 depends 'build-essential'
-depends 'nssm'
+depends 'nssm', '>= 3.0.1'
 depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -35,8 +35,8 @@ describe ConsulCookbook::Resource::ConsulService do
 
     it do
       expect(chef_run).to install_nssm('consul').with(
-        program: 'C:\Program Files\consul\0.8.3\consul.exe',
-        args: 'agent -config-file="""C:\Program Files\consul\consul.json""" -config-dir="""C:\Program Files\consul\conf.d"""'
+        program: 'C:\Program Files\consul\0.7.1\consul.exe',
+        args: 'agent -config-file="C:\Program Files\consul\consul.json" -config-dir="C:\Program Files\consul\conf.d"'
       )
     end
   end


### PR DESCRIPTION
nssm cookbook 3.0.1 introduced a breaking change dhoer/chef-nssm#17
The nssm resource is now performing parameter escaping.

Helpers libraries shouldn't try to also escape parameters.

*Cc:* @aboten