### PR TITLE
Add enable_script_checks config param

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -69,6 +69,7 @@ module ConsulCookbook
       attribute(:dns_config, kind_of: [Hash, Mash])
       attribute(:domain, kind_of: String)
       attribute(:enable_debug, equal_to: [true, false])
+      attribute(:enable_script_checks, equal_to: [true, false])
       attribute(:enable_syslog, equal_to: [true, false])
       attribute(:encrypt, kind_of: String)
       attribute(:http_api_response_headers, kind_of: [Hash, Mash])
@@ -148,6 +149,7 @@ module ConsulCookbook
           dns_config
           domain
           enable_debug
+          enable_script_checks
           enable_syslog
           encrypt
           http_api_response_headers


### PR DESCRIPTION
Script-based health checks are now opt-in -- Need to make this configurable to run Consul 0.9

https://www.hashicorp.com/blog/consul-0-9/