### PR TITLE
Leverage nssm 4.0.0 and remove obsolete code

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -46,81 +46,9 @@ module ConsulCookbook
 
     def command(config_file, config_dir)
       if windows?
-        %(agent -config-file="""#{config_file}""" -config-dir="""#{config_dir}""")
+        %(agent -config-file="#{config_file}" -config-dir="#{config_dir}")
       else
         "/usr/local/bin/consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
-      end
-    end
-
-    def nssm_exe
-      "#{node['nssm']['install_location']}\\nssm.exe"
-    end
-
-    def nssm_params
-      %w(Application
-         AppParameters
-         AppDirectory
-         AppExit
-         AppAffinity
-         AppEnvironment
-         AppEnvironmentExtra
-         AppNoConsole
-         AppPriority
-         AppRestartDelay
-         AppStdin
-         AppStdinShareMode
-         AppStdinCreationDisposition
-         AppStdinFlagsAndAttributes
-         AppStdout
-         AppStdoutShareMode
-         AppStdoutCreationDisposition
-         AppStdoutFlagsAndAttributes
-         AppStderr
-         AppStderrShareMode
-         AppStderrCreationDisposition
-         AppStderrFlagsAndAttributes
-         AppStopMethodSkip
-         AppStopMethodConsole
-         AppStopMethodWindow
-         AppStopMethodThreads
-         AppThrottle
-         AppRotateFiles
-         AppRotateOnline
-         AppRotateSeconds
-         AppRotateBytes
-         AppRotateBytesHigh
-         DependOnGroup
-         DependOnService
-         Description
-         DisplayName
-         ImagePath
-         ObjectName
-         Name
-         Start
-         Type)
-    end
-
-    def nssm_service_installed?
-      # 1 is command not found
-      # 3 is service not found
-      exit_code = shell_out!(%("#{nssm_exe}" status consul), returns: [0, 1, 3]).exitstatus
-      exit_code == 0
-    end
-
-    def nssm_service_status?(expected_status)
-      expected_status.include? shell_out!(%("#{nssm_exe}" status consul), returns: [0]).stdout.delete("\0").strip
-    end
-
-    # Returns a hash of mismatched params
-    def check_nssm_params(extra = {})
-      params = node['consul']['service']['nssm_params'].merge extra
-      # nssm can only get certain values
-      to_check = params.select { |k, _v| nssm_params.include? k.to_s }
-      to_check.each.each_with_object({}) do |(k, v), mismatch|
-        # shell_out! returns values with null bytes, need to delete them before we evaluate
-        unless shell_out!(%("#{nssm_exe}" get consul #{k}), returns: [0]).stdout.delete("\0").strip.eql? v.to_s
-          mismatch[k] = v
-        end
       end
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ supports 'arch'
 supports 'windows'
 
 depends 'build-essential'
-depends 'nssm'
+depends 'nssm', '>= 4.0.0'
 depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,6 @@
 #
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
-node.default['nssm']['install_location'] = '%WINDIR%'
-
 poise_service_user node['consul']['service_user'] do
   group node['consul']['service_group']
   shell node['consul']['service_shell'] unless node['consul']['service_shell'].nil?

--- a/test/spec/libraries/consul_service_windows_spec.rb
+++ b/test/spec/libraries/consul_service_windows_spec.rb
@@ -36,7 +36,7 @@ describe ConsulCookbook::Resource::ConsulService do
     it do
       expect(chef_run).to install_nssm('consul').with(
         program: 'C:\Program Files\consul\0.9.3\consul.exe',
-        args: 'agent -config-file="""C:\Program Files\consul\consul.json""" -config-dir="""C:\Program Files\consul\conf.d"""'
+        args: 'agent -config-file="C:\Program Files\consul\consul.json" -config-dir="C:\Program Files\consul\conf.d"'
       )
     end
   end


### PR DESCRIPTION
NSSM cookbook version 4 improved its parameter handling and idempotency.
No need to do weird quoting (this is a small breaking change!)

This replaces #455 and should fix #454
*Cc.* @aboten