### PR TITLE
add flags attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,7 @@ default['consul']['config']['ports'] = {
 default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
-default['consul']['service']['flags'] = ""
+default['consul']['service']['flags'] = ''
 
 default['consul']['version'] = '0.8.3'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default['consul']['config']['ports'] = {
 default['consul']['diplomat_version'] = nil
 
 default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
+default['consul']['service']['flags'] = ""
 
 default['consul']['version'] = '0.8.3'
 

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -50,9 +50,12 @@ module ConsulCookbook
       # The ACL token. Needed to reload the Consul service on Windows
       # @return [String]
       attribute(:acl_token, kind_of: String, default: lazy { node['consul']['config']['acl_master_token'] })
+      # @!attribute flags
+      # @return [String]
+      attribute(:flags, kind_of: String, default: lazy { node['consul']['service']['flags'] })
 
       def command
-        "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir}"
+        "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir} #{flags}"
       end
 
       def shell_environment


### PR DESCRIPTION
Consul needs runtime flags for some stuff (like running the UI).  This PR adds a flags attribute that allows that, and by default sets to to nothing.