### PR TITLE
Rename "to_json" to avoid collisions with built-in methods

### DIFF
--- a/libraries/consul_config.rb
+++ b/libraries/consul_config.rb
@@ -130,7 +130,7 @@ module ConsulCookbook
 
       # Transforms the resource into a JSON format which matches the
       # Consul service's configuration format.
-      def to_json
+      def params_to_json
         for_keeps = %i(
           acl_agent_token
           acl_agent_master_token
@@ -256,7 +256,7 @@ module ConsulCookbook
               group new_resource.group
               mode '0640'
             end
-            content new_resource.to_json
+            content new_resource.params_to_json
             sensitive true
           end
         end

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -35,7 +35,7 @@ module ConsulCookbook
       # @return [Hash]
       attribute(:parameters, option_collector: true, default: {})
 
-      def to_json
+      def params_to_json
         final_parameters = parameters
         final_parameters = final_parameters.merge(name: name) if final_parameters[:name].nil?
         JSON.pretty_generate(type => final_parameters)
@@ -56,7 +56,7 @@ module ConsulCookbook
           end
 
           file new_resource.path do
-            content new_resource.to_json
+            content new_resource.params_to_json
             unless platform?('windows')
               owner new_resource.user
               group new_resource.group

--- a/libraries/consul_watch.rb
+++ b/libraries/consul_watch.rb
@@ -35,7 +35,7 @@ module ConsulCookbook
       # @return [Hash]
       attribute(:parameters, option_collector: true, default: {})
 
-      def to_json
+      def params_to_json
         JSON.pretty_generate(watches: [{ type: type }.merge(parameters)])
       end
 
@@ -51,7 +51,7 @@ module ConsulCookbook
           end
 
           file new_resource.path do
-            content new_resource.to_json
+            content new_resource.params_to_json
             unless platform?('windows')
               owner new_resource.user
               group new_resource.group


### PR DESCRIPTION
Fixes #474 
Closes #475 

We need to rename the method `to_json` in order to avoid collisions with Chef built-in methods having the same name.

cc @gdavison, @Wing924 