### PR TITLE
Fix errors in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     sources:
       - chef-stable-trusty
     packages:
-      - chefdk
+      - chefdk=2.4.17-1
 
 install: echo "skip bundle install"
 services: docker


### PR DESCRIPTION
Use ChefDK 2.4.17. There is a known bug in ChefDK 2.5.3: YAML aliases don't work in kitchen 1.20.0 (fixed in 1.21)

https://github.com/test-kitchen/test-kitchen/issues/1353