### PR TITLE
Fix name collisions in helpers.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,11 +10,11 @@ default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
 default['consul']['create_service_user'] = true
 
-default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'
-default['consul']['config']['data_dir'] = data_path
-default['consul']['config']['ca_file'] = join_path config_prefix_path, 'ssl', 'CA', 'ca.crt'
-default['consul']['config']['cert_file'] = join_path config_prefix_path, 'ssl', 'certs', 'consul.crt'
-default['consul']['config']['key_file'] = join_path config_prefix_path, 'ssl', 'private', 'consul.key'
+default['consul']['config']['path'] = join_path config_prefix_path_consul, 'consul.json'
+default['consul']['config']['data_dir'] = data_path_consul
+default['consul']['config']['ca_file'] = join_path config_prefix_path_consul, 'ssl', 'CA', 'ca.crt'
+default['consul']['config']['cert_file'] = join_path config_prefix_path_consul, 'ssl', 'certs', 'consul.crt'
+default['consul']['config']['key_file'] = join_path config_prefix_path_consul, 'ssl', 'private', 'consul.key'
 
 default['consul']['config']['client_addr'] = '0.0.0.0'
 default['consul']['config']['ports'] = {
@@ -27,15 +27,15 @@ default['consul']['config']['ports'] = {
 
 default['consul']['diplomat_version'] = nil
 
-default['consul']['service']['config_dir'] = join_path config_prefix_path, 'conf.d'
+default['consul']['service']['config_dir'] = join_path config_prefix_path_consul, 'conf.d'
 
 default['consul']['version'] = '0.9.3'
 
 # Windows only
 default['consul']['service']['nssm_params'] = {
-  'AppDirectory'     => data_path,
-  'AppStdout'        => join_path(config_prefix_path, 'stdout.log'),
-  'AppStderr'        => join_path(config_prefix_path, 'error.log'),
+  'AppDirectory'     => data_path_consul,
+  'AppStdout'        => join_path(config_prefix_path_consul, 'stdout.log'),
+  'AppStderr'        => join_path(config_prefix_path_consul, 'error.log'),
   'AppRotateFiles'   => 1,
   'AppRotateOnline'  => 1,
   'AppRotateBytes'   => 20_000_000,

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -32,7 +32,7 @@ module ConsulCookbook
       # @return [Hash]
       # @api private
       def self.default_inversion_options(node, resource)
-        extract_path = node.platform_family?('windows') ? node.config_prefix_path : '/opt/consul'
+        extract_path = node.platform_family?('windows') ? node.config_prefix_path_consul : '/opt/consul'
         super.merge(extract_to: extract_path,
                     version: resource.version,
                     archive_url: 'https://releases.hashicorp.com/consul/%{version}/%{basename}',
@@ -58,15 +58,6 @@ module ConsulCookbook
           link '/usr/local/bin/consul' do
             to ::File.join(options[:extract_to], new_resource.version, 'consul')
             not_if { windows? }
-          end
-
-          link "#{node.config_prefix_path}\\consul.exe" do
-            to ::File.join(options[:extract_to], new_resource.version, 'consul.exe')
-            only_if { windows? }
-          end
-          windows_path node.config_prefix_path do
-            action :add
-            only_if { windows? }
           end
         end
       end

--- a/libraries/consul_service_windows.rb
+++ b/libraries/consul_service_windows.rb
@@ -37,7 +37,7 @@ module ConsulCookbook
             extend ConsulCookbook::Helpers
 
             program new_resource.program
-            args command(new_resource.config_file, new_resource.config_dir)
+            args command_consul(new_resource.config_file, new_resource.config_dir)
             parameters new_resource.nssm_params.select { |_k, v| v != '' }
             action :install
           end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -36,15 +36,15 @@ module ConsulCookbook
       join_path('C:', 'Program Files') + (arch_64? ? '' : ' x(86)')
     end
 
-    def config_prefix_path
+    def config_prefix_path_consul
       windows? ? join_path(program_files, 'consul') : join_path('/etc', 'consul')
     end
 
-    def data_path
+    def data_path_consul
       windows? ? join_path(program_files, 'consul', 'data') : join_path('/var/lib', 'consul')
     end
 
-    def command(config_file, config_dir)
+    def command_consul(config_file, config_dir)
       if windows?
         %(agent -config-file="#{config_file}" -config-dir="#{config_dir}")
       else


### PR DESCRIPTION
When a run_list includes consul and hashicorp-vault their helpers inject into the node colliding def blocks.

Depending on the order of inclusion, `consul` or `vault` is used, when it should be the other.

Solves: https://github.com/johnbellone/consul-cookbook/issues/498