### PR TITLE
Stop sending helper into node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Removed node send in helper.rb (Stop polutiting node object - Collides with hashicorp-vault too. So the practice should be stopped. Added extend to attributes/default
+
 ## [v3.0.0](https://github.com/johnbellone/consul-cookbook/tree/v3.0.0) (2017-06-11)
 [Full Changelog](https://github.com/johnbellone/consul-cookbook/compare/v2.3.0...v3.0.0)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,8 @@
 # Copyright 2014-2016, Bloomberg Finance L.P.
 #
 
+extend ConsulCookbook::Helpers
+
 default['consul']['service_name'] = 'consul'
 default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,5 +53,3 @@ module ConsulCookbook
     end
   end
 end
-
-Chef::Node.send(:include, ConsulCookbook::Helpers)


### PR DESCRIPTION
Removed: Chef::Node.send(:include, ConsulCookbook::Helpers) from helper
Added extend ConsulCookbook::Helpers to attributes/default.rb

Run in windows, centos6 and centos7 via test kitchen.

Second kick at the can, so to speak. Solves: https://github.com/johnbellone/consul-cookbook/issues/498